### PR TITLE
fix: remove internal `npm install` call from `npx snapwp` command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,7 @@ To create a new headless WordPress app using SnapWP, follow these steps:
 1. Run the scaffolding wizard:
 
     ```bash
-    npx snapwp create-app
+    npx snapwp
     ```
 
 2. Answer the CLI prompts:
@@ -59,8 +59,9 @@ To create a new headless WordPress app using SnapWP, follow these steps:
 
 3. Start your headless WordPress app:
     1. Navigate to the newly created app.
-    2. Run `npm run dev` (for development) or `npm run build && npm run start` (for production)
-    3. Visit the `NEXT_PUBLIC_URL` from `.env` (updated in Step 2), in your browser to see SnapWP in action!
+    2. Run `npm install`.
+    3. Run `npm run dev` (for development) or `npm run build && npm run start` (for production)
+    4. Visit the `NEXT_PUBLIC_URL` from `.env` (updated in Step 2), in your browser to see SnapWP in action!
 
 ### Manual Installation
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,55 @@
+# SnapWP Setup
+
+## Prerequisites
+
+-   **Node.js**: v20+ (with `npm and `npx` installed).
+-   **A WordPress backend** [configured with SnapWP Helper](https://github.com/rtCamp/snapwp/blob/develop/docs/getting-started.md#backend-setup).
+
+## Using through npx
+
+To create a new headless WordPress app using SnapWP, follow these steps:
+
+1. Run the scaffolding wizard:
+
+    ```bash
+    npx snapwp
+    ```
+
+2. Answer the CLI prompts:
+
+    1. Enter the path to the directory where you want to create the app, e.g. `./my-headless-app`
+    2. Create an Environment File:
+
+        1. Paste the .env contents from `Dashboard > WPGraphQL > Settings > SnapWP Helper into the file created.
+
+         <a href="https://github.com/rtCamp/snapwp/blob/develop/docs/images/snapwp-helper-env.png">
+           <!--@todo: link to snapwp-helper repo for image-->
+           <img src="https://raw.githubusercontent.com/rtCamp/snapwp/refs/heads/develop/docs/images/snapwp-helper-env.png" alt="Example environment variables from SnapWP Helper plugin screen." style="width: 300px;">
+           <p> Example environment variables from SnapWP Helper plugin screen. (Click for full screen)</p>
+         </a>
+
+        2. Uncomment and update the `NEXT_PUBLIC_URL` variable to match the URL of your frontend app, and adjust any other environment variables as needed.
+        3. Save the file and close the editor.
+
+    3. Return to the terminal and press `Enter` to continue the setup process.
+
+3. Start your SnapWP app:
+    1. Navigate to the newly created app.
+    2. Run `npm install`.
+    3. Run `npm run dev` (for development) or `npm run build && npm run start` (for production)
+    4. Visit the `NEXT_PUBLIC_URL` from `.env` (updated in Step 2), in your browser to see SnapWP in action!
+
+## Development
+
+### Using linking (useful while developing)
+
+1. Clone the [SnapWP](https://github.com/rtCamp/snapwp) repository using `git clone https://github.com/rtCamp/snapwp.git`.
+2. `npm run build` to build the packages. (Alternatively, `npm run build -w snapwp` to only build the script)
+3. `npm link -w snapwp` to link the package to your global dependencies. This exposes `snapwp` as a CLI command.
+4. `snapwp` will be available to be used.
+5. `npm r snapwp -g` to remove the link.
+
+### Using Verdaccio (useful while testing pre-release)
+
+1. `npm run publish:local` to build and publish.
+2. Run `snapwp --proxy` to scaffold the project which uses dependencies from local registry.

--- a/packages/cli/build.cjs
+++ b/packages/cli/build.cjs
@@ -13,7 +13,9 @@ const fs = require( 'fs/promises' );
 	await fs.cp( examplesDir, path.resolve( __dirname, './dist/examples' ), {
 		recursive: true,
 		filter: ( source ) =>
-			! /.*(node_modules|package-lock.json)/g.test( source ),
+			! /.*(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)/g.test(
+				source
+			),
 	} );
 	await fs.cp( srcDir, path.resolve( __dirname, './dist' ), {
 		recursive: true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "snapwp",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"license": "AGPL-3.0",
 	"author": "rtCamp",
 	"description": "A better way to build headless WordPress applications.",

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -115,7 +115,9 @@ const openEditor = ( filePath ) => {
 			{
 				recursive: true,
 				filter: ( source ) =>
-					! /.*(node_modules|package-lock.json)/g.test( source ),
+					! /.*(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)/g.test(
+						source
+					),
 			},
 			( error ) => {
 				if ( ! error ) {

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -205,20 +205,21 @@ const openEditor = ( filePath ) => {
 			updatedPackageJsonData
 		);
 
-		// Step 6: CD into project directory and run `npm install && npm run build` to build the frontend.
-		exec( 'npm install', { cwd: projectDirPath } );
-		exec( 'npm run build', { cwd: projectDirPath } );
-		console.log( '🌐 Built example frontend.' );
+		// New line for clarity.
+		console.log( '' );
 
 		console.log(
 			`✔️ Your project has been scaffolded at: ${ projectDirPath }.`
 		);
+
 		// New line for clarity.
 		console.log( '' );
-		console.log(
-			`🚀 To start your headless WordPress project, please navigate to ${ projectDirPath } ` +
-				'and run `npm run start`.'
-		);
+
+		console.log( '🚀 To start your headless WordPress project, please run the following commands:' );
+		console.log( `cd ${ projectDirPath }` );
+		console.log( `npm install` );
+		console.log( `npm run dev` );
+
 	} catch ( error ) {
 		console.error( 'Error:', error );
 		process.exit( 1 );

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -109,11 +109,23 @@ const openEditor = ( filePath ) => {
 		fs.rmSync( nextJSStarterEnvPath, { force: true } ); // Delete `.env` from starter if present, to prevent override of `.env`.
 
 		console.log( '📂 Copying frontend folder to project directory...' );
-		fs.cpSync( nextJsStarterPath, projectDirPath, {
-			recursive: true,
-			filter: ( source ) =>
-				! /.*(node_modules|package-lock.json)/g.test( source ),
-		} );
+		await fs.cp(
+			nextJsStarterPath,
+			projectDirPath,
+			{
+				recursive: true,
+				filter: ( source ) =>
+					! /.*(node_modules|package-lock.json)/g.test( source ),
+			},
+			( error ) => {
+				if ( ! error ) {
+					return;
+				}
+
+				console.log( 'Error: ', error );
+				process.exit( 1 );
+			}
+		);
 
 		// @todo: Add interactive support to prompt for the env variable values one-at-a-time, create `.env` file using it in projectDirPath if --interactive is passed & skip `Step 3`.
 

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -215,11 +215,12 @@ const openEditor = ( filePath ) => {
 		// New line for clarity.
 		console.log( '' );
 
-		console.log( '🚀 To start your headless WordPress project, please run the following commands:' );
+		console.log(
+			'🚀 To start your headless WordPress project, please run the following commands:'
+		);
 		console.log( `cd ${ projectDirPath }` );
 		console.log( `npm install` );
 		console.log( `npm run dev` );
-
 	} catch ( error ) {
 		console.error( 'Error:', error );
 		process.exit( 1 );


### PR DESCRIPTION
## What
- This PR 
    - Updates `docs/getting-started.md` doc.
    - Adds `packages/cli/README.md`.
    - Adds the following files/folders to ignore list of SnapWP command:
        - .env
        - .next
        - next-env.d.ts
        - src/__generated
    - Updates `fs.cpSync` function to `fs.cp` in SnapWP command.
    - Removes `npm install` from SnapWP command adds user steps for the same.

## Why
- To fix SnapWP command and to add proper documentation.

### Related Issue(s):
- https://github.com/rtCamp/headless/issues/303


## Testing Instructions
- Runs the `Development` from `packages/cli/README.md`.

## Checklist

-   [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation accordingly.
