### PR TITLE
fix: update regex in `snapwp` command to avoid `node_modules`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "snapwp",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"license": "AGPL-3.0",
 	"author": "rtCamp",
 	"description": "A better way to build headless WordPress applications.",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "snapwp",
-	"version": "0.0.3",
+	"version": "0.0.2",
 	"license": "AGPL-3.0",
 	"author": "rtCamp",
 	"description": "A better way to build headless WordPress applications.",

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -115,9 +115,11 @@ const openEditor = ( filePath ) => {
 			{
 				recursive: true,
 				filter: ( source ) => {
-					const fileCheck = new RegExp( `/${nextJsStarterPath}/(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)$` );
+					const fileCheck = new RegExp(
+						`/${ nextJsStarterPath }/(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)$`
+					);
 					return ! fileCheck.test( source );
-				}
+				},
 			},
 			( error ) => {
 				if ( ! error ) {

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -114,10 +114,10 @@ const openEditor = ( filePath ) => {
 			projectDirPath,
 			{
 				recursive: true,
-				filter: ( source ) =>
-					! /.*(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)/g.test(
-						source
-					),
+				filter: ( source ) => {
+					const fileCheck = new RegExp( `/${nextJsStarterPath}/(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)$` );
+					return ! fileCheck.test( source );
+				}
 			},
 			( error ) => {
 				if ( ! error ) {


### PR DESCRIPTION
## What
- This PR updates the regex for snapwp command.

### Related Issue(s):
- https://github.com/rtCamp/headless/issues/303

## Testing Instructions
- Run the `Development` from `packages/cli/README.md`.

## Additional Information

- The previous regex was matching the node_modules path:

i.e. if our scaffold path is
`/Users/amaankhan/.nvm/versions/node/v20.10.0/lib/node_modules/snapwp/dist/examples/nextjs/starter/`
then our previous regex i.e. `/.*(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)/g` will always return true.

<img width="1440" alt="Screenshot 2025-01-31 at 8 41 36 PM" src="https://github.com/user-attachments/assets/81e9826a-4efb-4e4e-9c3a-886d0c1640e0" />


## Checklist
-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [ ] My code has detailed inline documentation.
-   [x] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation accordingly.
