### PR TITLE
Fix: Absolute Path import issue with windows - ERR_UNSUPPORTED_ESM_URL_SCHEME

### DIFF
--- a/packages/next/src/config/with-snap-wp.ts
+++ b/packages/next/src/config/with-snap-wp.ts
@@ -83,24 +83,23 @@ const withSnapWP = async ( nextConfig?: NextConfig ): Promise< NextConfig > => {
 	];
 
 	// Locate the SnapWP configuration file.
-	let snapWPConfigPath = possibleSnapWPConfigPaths.find( ( path ) => {
-		return fs.existsSync( path );
-	} );
+	let snapWPConfigPath = possibleSnapWPConfigPaths.find(
+		( possibleSnapWPConfigPath ) => {
+			return fs.existsSync( possibleSnapWPConfigPath );
+		}
+	);
 
 	if ( ! snapWPConfigPath ) {
 		throw new Error( 'SnapWP configuration file not found.' );
 	}
 
 	// Platform-specific handling
-	if (process.platform === 'win32') {
+	if ( process.platform === 'win32' ) {
 		// Use path.normalize to replace backslashes correctly
-		snapWPConfigPath = path.normalize(snapWPConfigPath);
+		snapWPConfigPath = path.normalize( snapWPConfigPath );
 		// Convert it to a file:// URL
-		snapWPConfigPath = url.pathToFileURL(snapWPConfigPath).href;
+		snapWPConfigPath = url.pathToFileURL( snapWPConfigPath ).href;
 	}
-
-	console.log(snapWPConfigPath);
-
 
 	const snapWPConfig = ( await import( snapWPConfigPath ) ).default;
 	setConfig( snapWPConfig );

--- a/packages/next/src/config/with-snap-wp.ts
+++ b/packages/next/src/config/with-snap-wp.ts
@@ -1,5 +1,7 @@
 import { type NextConfig } from 'next';
 import fs from 'fs';
+import path from 'path';
+import url from 'url';
 import { getConfig, setConfig } from '@snapwp/core/config';
 import {
 	ModifySourcePlugin,
@@ -81,13 +83,24 @@ const withSnapWP = async ( nextConfig?: NextConfig ): Promise< NextConfig > => {
 	];
 
 	// Locate the SnapWP configuration file.
-	const snapWPConfigPath = possibleSnapWPConfigPaths.find( ( path ) => {
+	let snapWPConfigPath = possibleSnapWPConfigPaths.find( ( path ) => {
 		return fs.existsSync( path );
 	} );
 
 	if ( ! snapWPConfigPath ) {
 		throw new Error( 'SnapWP configuration file not found.' );
 	}
+
+	// Platform-specific handling
+	if (process.platform === 'win32') {
+		// Use path.normalize to replace backslashes correctly
+		snapWPConfigPath = path.normalize(snapWPConfigPath);
+		// Convert it to a file:// URL
+		snapWPConfigPath = url.pathToFileURL(snapWPConfigPath).href;
+	}
+
+	console.log(snapWPConfigPath);
+
 
 	const snapWPConfig = ( await import( snapWPConfigPath ) ).default;
 	setConfig( snapWPConfig );


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->
- This PR fixes the `ERR_UNSUPPORTED_ESM_URL_SCHEME` error, which occurs on Windows when using an absolute path without the `file:` or `data:` scheme.



## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
- On Windows, `C:/` is interpreted as a protocol, making it an invalid protocol. Since it represents a directory, absolute paths in the Windows filesystem require a scheme to function correctly.


### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->
- Closes: #37 


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
- First, we normalize the path using the `path` Node.js API.  
- Then, we convert it to a file URL using the `url` Node.js API.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Scaffold the example in your Windows system.
2. Install all dependencies
3. Execute npm run dev or npm run build - It should be executed successfully.



## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation accordingly.
