### PR TITLE
Refactor: Updates snapwp command

### DIFF
--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -111,28 +111,13 @@ const openEditor = ( filePath ) => {
 			'./examples/nextjs/starter/'
 		);
 
-		// Step 2: Copy the _entire_ `nextJsStarterPath` contents to the project directory.
-		const nextJSStarterEnvPath = path.join( nextJsStarterPath, '.env' );
-		await fs.rm( nextJSStarterEnvPath, { force: true } ); // Delete `.env` from starter if present, to prevent override of `.env`.
-
-		console.log( '📂 Copying frontend folder to project directory...' );
-		await fs.cp( nextJsStarterPath, projectDirPath, {
-			recursive: true,
-			filter: ( source ) => {
-				const fileCheck = new RegExp(
-					`/${ nextJsStarterPath }/(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)$`
-				);
-				return ! fileCheck.test( source );
-			},
-		} );
-
 		// @todo: Add interactive support to prompt for the env variable values one-at-a-time, create `.env` file using it in projectDirPath if --interactive is passed & skip `Step 3`.
 
 		// @todo: Create `.env` file directly with env_variables if --{specific_env_variable}={value} or --interactive is passed & skip `Step 3`.
 
 		// @todo: Copy `.env` file to projectDirPath if file-path passed via --env_file={string or path} & skip `Step 3`.
 
-		// Step 3: Check if there is an `.env` file in projectDirPath.
+		// Step 2: Check if there is an `.env` file in projectDirPath.
 		const envPath = path.join( projectDirPath, '.env' );
 
 		try {
@@ -199,6 +184,21 @@ const openEditor = ( filePath ) => {
 
 			process.exit( 1 );
 		}
+
+		// Step 3: Copy the _entire_ `nextJsStarterPath` contents to the project directory.
+		const nextJSStarterEnvPath = path.join( nextJsStarterPath, '.env' );
+		await fs.rm( nextJSStarterEnvPath, { force: true } ); // Delete `.env` from starter if present, to prevent override of `.env`.
+
+		console.log( '📂 Copying frontend folder to project directory...' );
+		await fs.cp( nextJsStarterPath, projectDirPath, {
+			recursive: true,
+			filter: ( source ) => {
+				const fileCheck = new RegExp(
+					`/${ nextJsStarterPath }/(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)$`
+				);
+				return ! fileCheck.test( source );
+			},
+		} );
 
 		// Step 4: Create .npmrc file in project directory if running via proxy registry.
 		if ( options.proxy ) {

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -116,19 +116,15 @@ const openEditor = ( filePath ) => {
 		await fs.rm( nextJSStarterEnvPath, { force: true } ); // Delete `.env` from starter if present, to prevent override of `.env`.
 
 		console.log( '📂 Copying frontend folder to project directory...' );
-		await fs.cp(
-			nextJsStarterPath,
-			projectDirPath,
-			{
-				recursive: true,
-				filter: ( source ) => {
-					const fileCheck = new RegExp(
-						`/${ nextJsStarterPath }/(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)$`
-					);
-					return ! fileCheck.test( source );
-				},
-			}
-		);
+		await fs.cp( nextJsStarterPath, projectDirPath, {
+			recursive: true,
+			filter: ( source ) => {
+				const fileCheck = new RegExp(
+					`/${ nextJsStarterPath }/(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)$`
+				);
+				return ! fileCheck.test( source );
+			},
+		} );
 
 		// @todo: Add interactive support to prompt for the env variable values one-at-a-time, create `.env` file using it in projectDirPath if --interactive is passed & skip `Step 3`.
 
@@ -149,10 +145,10 @@ const openEditor = ( filePath ) => {
 
 			await prompt(
 				`\nNo .env file found in "${ projectDirPath }". Please \n` +
-				'  1. Press any key to open a new .env file in your default editor,\n' +
-				'  2. Paste in the environment variables from your WordPress site, and update the values as needed. \n' +
-				'  3. Save and close the file to continue the installation. \n' +
-				'\n (For more information on configuring your .env file, see the SnapWP documentation.)' // @todo Update with the link to the documentation.
+					'  1. Press any key to open a new .env file in your default editor,\n' +
+					'  2. Paste in the environment variables from your WordPress site, and update the values as needed. \n' +
+					'  3. Save and close the file to continue the installation. \n' +
+					'\n (For more information on configuring your .env file, see the SnapWP documentation.)' // @todo Update with the link to the documentation.
 			);
 
 			/**
@@ -187,7 +183,6 @@ const openEditor = ( filePath ) => {
 				// Exit if any other unknown error occurred.
 				console.error( 'Error:', error );
 				process.exit( 1 );
-
 			}
 		}
 

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -11,13 +11,39 @@ const { program } = require( 'commander' );
 
 program
 	.option( '--proxy', 'Use proxy registry.' )
-	.requiredOption( '--NEXT_PUBLIC_WORDPRESS_URL <string>', 'WordPress "frontend" domain URL.' )
-	.requiredOption( '--INTROSPECTION_TOKEN <string>', 'Token used for authenticating GraphQL introspection queries.' )
-	.option( '--NODE_TLS_REJECT_UNAUTHORIZED <string>', 'Enable if connecting to a self-signed cert.', '0' )
-	.option( '--NEXT_PUBLIC_URL <string>', 'Headless frontend domain URL.', 'http://localhost:3000' )
-	.option( '--NEXT_PUBLIC_GRAPHQL_ENDPOINT <string>', 'WordPress GraphQL endpoint.', 'graphql' )
-	.option( '--NEXT_PUBLIC_WORDPRESS_UPLOADS_PATH <string>', 'WordPress Uploads directory path.', '/wp-content/uploads' )
-	.option( '--NEXT_PUBLIC_WORDPRESS_REST_URL_PREFIX <string>', 'WordPress REST URL Prefix.', '/wp-json' )
+	.requiredOption(
+		'--NEXT_PUBLIC_WORDPRESS_URL <string>',
+		'WordPress "frontend" domain URL.'
+	)
+	.requiredOption(
+		'--INTROSPECTION_TOKEN <string>',
+		'Token used for authenticating GraphQL introspection queries.'
+	)
+	.option(
+		'--NODE_TLS_REJECT_UNAUTHORIZED <string>',
+		'Enable if connecting to a self-signed cert.',
+		'0'
+	)
+	.option(
+		'--NEXT_PUBLIC_URL <string>',
+		'Headless frontend domain URL.',
+		'http://localhost:3000'
+	)
+	.option(
+		'--NEXT_PUBLIC_GRAPHQL_ENDPOINT <string>',
+		'WordPress GraphQL endpoint.',
+		'graphql'
+	)
+	.option(
+		'--NEXT_PUBLIC_WORDPRESS_UPLOADS_PATH <string>',
+		'WordPress Uploads directory path.',
+		'/wp-content/uploads'
+	)
+	.option(
+		'--NEXT_PUBLIC_WORDPRESS_REST_URL_PREFIX <string>',
+		'WordPress REST URL Prefix.',
+		'/wp-json'
+	)
 	.parse();
 
 const options = program.opts();
@@ -135,32 +161,28 @@ const openEditor = ( filePath ) => {
 				process.exit( 1 );
 			}
 
-			const envFileData = `# Enable if connecting to a self-signed cert\n` +
+			const envFileData =
+				`# Enable if connecting to a self-signed cert\n` +
 				`NODE_TLS_REJECT_UNAUTHORIZED=${ options.NODE_TLS_REJECT_UNAUTHORIZED }\n\n` +
-
 				`# The headless frontend domain URL. Uncomment this line and ensure the value matches the URL used by your frontend app.\n` +
 				`NEXT_PUBLIC_URL=${ options.NEXT_PUBLIC_URL }\n\n` +
-
 				`# The WordPress "frontend" domain URL\n` +
 				`NEXT_PUBLIC_WORDPRESS_URL=${ options.NEXT_PUBLIC_WORDPRESS_URL }\n\n` +
-
 				`# The WordPress GraphQL endpoint\n` +
 				`NEXT_PUBLIC_GRAPHQL_ENDPOINT=${ options.NEXT_PUBLIC_GRAPHQL_ENDPOINT }\n\n` +
-
 				`# The WordPress Uploads directory path\n` +
 				`# NEXT_PUBLIC_WORDPRESS_UPLOADS_PATH=${ options.NEXT_PUBLIC_WORDPRESS_UPLOADS_PATH }\n\n` +
-
 				`# The WordPress REST URL Prefix\n` +
 				`# NEXT_PUBLIC_WORDPRESS_REST_URL_PREFIX=${ options.NEXT_PUBLIC_WORDPRESS_REST_URL_PREFIX }\n\n` +
-
 				`# Token used for authenticating GraphQL introspection queries\n` +
 				`INTROSPECTION_TOKEN=${ options.INTROSPECTION_TOKEN }\n`;
 
-			console.log( `\nNo ".env" file found in "${ projectDirPath }". Creating ".env" file.` );
+			console.log(
+				`\nNo ".env" file found in "${ projectDirPath }". Creating ".env" file.`
+			);
 
 			// Create ".env" file.
 			await fs.writeFile( envPath, envFileData );
-
 		}
 
 		// Step 3: Copy the _entire_ `nextJsStarterPath` contents to the project directory.

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -4,7 +4,7 @@ const npmrcContent = `@snapwp:registry=${ registryURL }`;
 
 // Scaffold a new directory with the SnapWP build and the .env file.
 const { execSync, spawn } = require( 'child_process' );
-const fs = require( 'fs' );
+const fs = require( 'fs/promises' );
 const path = require( 'path' );
 const readline = require( 'readline' );
 const { program } = require( 'commander' );
@@ -95,8 +95,15 @@ const openEditor = ( filePath ) => {
 		const projectDirPath = path.resolve( projectDir );
 
 		// Create the project directory if not exists.
-		if ( ! fs.existsSync( projectDirPath ) ) {
-			fs.mkdirSync( projectDirPath, { recursive: true } );
+		try {
+			await fs.access( projectDirPath );
+		} catch ( error ) {
+			if ( 'ENOENT' !== error.code ) {
+				console.error( 'Error:', error );
+				process.exit( 1 );
+			}
+
+			await fs.mkdir( projectDirPath, { recursive: true } );
 		}
 
 		const nextJsStarterPath = path.resolve(
@@ -106,7 +113,7 @@ const openEditor = ( filePath ) => {
 
 		// Step 2: Copy the _entire_ `nextJsStarterPath` contents to the project directory.
 		const nextJSStarterEnvPath = path.join( nextJsStarterPath, '.env' );
-		fs.rmSync( nextJSStarterEnvPath, { force: true } ); // Delete `.env` from starter if present, to prevent override of `.env`.
+		await fs.rm( nextJSStarterEnvPath, { force: true } ); // Delete `.env` from starter if present, to prevent override of `.env`.
 
 		console.log( '📂 Copying frontend folder to project directory...' );
 		await fs.cp(
@@ -120,14 +127,6 @@ const openEditor = ( filePath ) => {
 					);
 					return ! fileCheck.test( source );
 				},
-			},
-			( error ) => {
-				if ( ! error ) {
-					return;
-				}
-
-				console.log( 'Error: ', error );
-				process.exit( 1 );
 			}
 		);
 
@@ -140,13 +139,20 @@ const openEditor = ( filePath ) => {
 		// Step 3: Check if there is an `.env` file in projectDirPath.
 		const envPath = path.join( projectDirPath, '.env' );
 
-		if ( ! fs.existsSync( envPath ) ) {
+		try {
+			await fs.access( envPath );
+		} catch ( error ) {
+			if ( 'ENOENT' !== error.code ) {
+				console.error( 'Error:', error );
+				process.exit( 1 );
+			}
+
 			await prompt(
 				`\nNo .env file found in "${ projectDirPath }". Please \n` +
-					'  1. Press any key to open a new .env file in your default editor,\n' +
-					'  2. Paste in the environment variables from your WordPress site, and update the values as needed. \n' +
-					'  3. Save and close the file to continue the installation. \n' +
-					'\n (For more information on configuring your .env file, see the SnapWP documentation.)' // @todo Update with the link to the documentation.
+				'  1. Press any key to open a new .env file in your default editor,\n' +
+				'  2. Paste in the environment variables from your WordPress site, and update the values as needed. \n' +
+				'  3. Save and close the file to continue the installation. \n' +
+				'\n (For more information on configuring your .env file, see the SnapWP documentation.)' // @todo Update with the link to the documentation.
 			);
 
 			/**
@@ -155,7 +161,7 @@ const openEditor = ( filePath ) => {
 			 * In Windows, if notepad is default editor, it saves files in `.txt` extension by default.
 			 * Creating a file before opening will prevent bugs due to default editor extensions.
 			 */
-			fs.closeSync( fs.openSync( envPath, 'w' ) );
+			await fs.writeFile( envPath, '' );
 
 			const envFileCreationStatus = await openEditor( envPath );
 
@@ -166,25 +172,43 @@ const openEditor = ( filePath ) => {
 				process.exit( 1 );
 			}
 
-			// Throw error if .env file still does not exist or if exists, its empty.
-			if (
-				! fs.existsSync( envPath ) ||
-				0 === fs.statSync( envPath ).size
-			) {
-				console.error(
-					`".env" still not found at "${ envPath }" or is empty. Please create an ".env" and try again.`
-				);
+			try {
+				await fs.access( envPath );
+			} catch ( error ) {
+				// Throw error if .env file still does not exist.
+				if ( 'ENOENT' === error.code ) {
+					console.error(
+						`".env" still not found at "${ envPath }". Please create an ".env" and try again.`
+					);
 
-				fs.rmSync( envPath, { force: true } ); // Delete old env for a fresh start.
+					process.exit( 1 );
+				}
 
+				// Exit if any other unknown error occurred.
+				console.error( 'Error:', error );
 				process.exit( 1 );
+
 			}
+		}
+
+		// Fetch the `.env` file size.
+		const { size } = await fs.stat( envPath );
+
+		// Throw error if .env file is empty.
+		if ( 0 === size ) {
+			console.error(
+				`An empty ".env" found at "${ envPath }". Please try again with a non-empty ".env" file.`
+			);
+
+			await fs.rm( envPath, { force: true } ); // Delete old env for a fresh start.
+
+			process.exit( 1 );
 		}
 
 		// Step 4: Create .npmrc file in project directory if running via proxy registry.
 		if ( options.proxy ) {
 			console.log( 'Found --proxy flag, generating `.npmrc` file.' );
-			fs.writeFileSync(
+			await fs.writeFile(
 				path.join( projectDirPath, '.npmrc' ),
 				npmrcContent
 			);
@@ -194,7 +218,7 @@ const openEditor = ( filePath ) => {
 		}
 
 		// Step 5: update @snapwp package version numbers in package.json.
-		const packageJsonData = fs.readFileSync(
+		const packageJsonData = await fs.readFile(
 			path.join( projectDirPath, 'package.json' ),
 			{ encoding: 'utf8' }
 		);
@@ -202,7 +226,7 @@ const openEditor = ( filePath ) => {
 			/file:..\/..\/..\/packages\/(blocks|query|core|next|codegen-config|eslint-config|prettier-config)/g,
 			'*'
 		);
-		fs.writeFileSync(
+		await fs.writeFile(
 			path.join( projectDirPath, 'package.json' ),
 			updatedPackageJsonData
 		);


### PR DESCRIPTION
## What
- This PR:
    - Adds option to pass `.env` file keys as CLI parameters.
    - Functionality to generate `.env` file dynamically as per the CLI params passed.
    - Moves the `.env` file generation from step 3 to step 2 in our command.
    - Fixes fs.cp (copy) functionality in snapwp command.
    - Migrates snapwp command from `fs` to `fs/promises`.

### Related Issue(s):
- https://github.com/orgs/rtCamp/projects/141/views/14?pane=issue&itemId=96437176

## Testing Instructions
- Run the Development from `packages/cli/README.md`.

## Checklist

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation accordingly.
