### PR TITLE
docs: cleanup `Getting Started` instructions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,12 +18,13 @@ This guide will walk you through setting up a headless WordPress app using SnapW
     - [WPGraphQL Content Blocks](https://github.com/wpengine/wp-graphql-content-blocks/releases/latest)
     - [SnapWP Helper](https://github.com/rtCamp/snapwp-helper/releases/latest)
 
-    > [!TIP]
-    > You can install the latest versions of the required plugins using the WP-CLI command below:
-    >
-    > ```bash
-    > wp plugin install wp-graphql https://github.com/wpengine/wp-graphql-content-blocks/releases/latest/download/wp-graphql-content-blocks.zip https://github.com/rtCamp/snapwp-helper/releases/latest/download/snapwp-helper.zip --activate
-    > ```
+    **With WP-CLI**:
+
+    You can install the latest versions of the required plugins using the WP-CLI command below:
+    
+    ```bash
+    wp plugin install wp-graphql https://github.com/wpengine/wp-graphql-content-blocks/releases/latest/download/wp-graphql-content-blocks.zip https://github.com/rtCamp/snapwp-helper/releases/latest/download/snapwp-helper.zip --activate
+    ```
 
 2. (Optional) If you're running your WordPress site on a different domain than your frontend, you may need to [configure CORS headers](./cors.md).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,7 +60,7 @@ To create a new headless WordPress app using SnapWP, follow these steps:
            </figure>
          </a>
 
-        2. Uncomment and update the `NEXT_PUBLIC_URL` variable to match the URL of your frontend app, and adjust any other [environment variables as needed](./usage.md#example-env-file).
+        2. Uncomment and update the `NEXT_PUBLIC_URL` variable to match the URL of your frontend app, and adjust any other [environment variables as needed](./config-api.md#environment-variables).
         3. Save the file and close the editor.
 
     3. Return to the terminal and press `Enter` to continue the setup process.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,13 +12,18 @@ This guide will walk you through setting up a headless WordPress app using SnapW
 
 ### Installation Steps
 
-1. Install and activate the latest release versions of the following plugins: - [WPGraphQL](https://wordpress.org/plugins/wp-graphql/) - [WPGraphQL Content Blocks](https://github.com/wpengine/wp-graphql-content-blocks/releases/latest) - [SnapWP Helper](https://github.com/rtCamp/snapwp-helper/releases/latest)
+1. Install and activate the latest release versions of the following plugins:
 
-    ```bash
-    # With WP-CLI
+    - [WPGraphQL](https://wordpress.org/plugins/wp-graphql/)
+    - [WPGraphQL Content Blocks](https://github.com/wpengine/wp-graphql-content-blocks/releases/latest)
+    - [SnapWP Helper](https://github.com/rtCamp/snapwp-helper/releases/latest)
 
-    wp plugin install wp-graphql https://github.com/wpengine/wp-graphql-content-blocks/releases/latest/download/wp-graphql-content-blocks.zip https://github.com/rtCamp/snapwp-helper/releases/latest/download/snapwp-helper.zip --activate
-    ```
+    > [!TIP]
+    > You can install the latest versions of the required plugins using the WP-CLI command below:
+    >
+    > ```bash
+    > wp plugin install wp-graphql https://github.com/wpengine/wp-graphql-content-blocks/releases/latest/download/wp-graphql-content-blocks.zip https://github.com/rtCamp/snapwp-helper/releases/latest/download/snapwp-helper.zip --activate
+    > ```
 
 2. (Optional) If you're running your WordPress site on a different domain than your frontend, you may need to [configure CORS headers](./cors.md).
 
@@ -27,7 +32,7 @@ This guide will walk you through setting up a headless WordPress app using SnapW
 ### Prerequisites
 
 -   **Node.js**: v20+ (with `npm` and `npx` installed).
--   **A WordPress backend** [configured with SnapWP Helper](#backend-setup).
+-   **A WordPress backend** configured with SnapWP Helper (see [previous section](#backend-setup)).
 
 ### Installation Steps
 
@@ -47,9 +52,11 @@ To create a new headless WordPress app using SnapWP, follow these steps:
         1. Paste the .env contents from `Dashboard > WPGraphQL > Settings > SnapWP Helper into the file created.
 
          <a href="./images/snapwp-helper-env.png">
-           <!--@todo: link to snapwp-helper repo for image-->
-           <img src="./images/snapwp-helper-env.png" alt="Example environment variables from SnapWP Helper plugin screen." style="width: 300px;">
-           <p> Example environment variables from SnapWP Helper plugin screen. (Click for full screen)</p>
+           <figure>
+             <!--@todo: link to snapwp-helper repo for image-->
+             <img src="./images/snapwp-helper-env.png" alt="Example environment variables from SnapWP Helper plugin screen." style="width: 300px;">
+             <figcaption> Example environment variables from SnapWP Helper plugin screen. (Click for full screen)</figcaption>
+           </figure>
          </a>
 
         2. Uncomment and update the `NEXT_PUBLIC_URL` variable to match the URL of your frontend app, and adjust any other [environment variables as needed](./usage.md#example-env-file).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ This guide will walk you through setting up a headless WordPress app using SnapW
     **With WP-CLI**:
 
     You can install the latest versions of the required plugins using the WP-CLI command below:
-    
+
     ```bash
     wp plugin install wp-graphql https://github.com/wpengine/wp-graphql-content-blocks/releases/latest/download/wp-graphql-content-blocks.zip https://github.com/rtCamp/snapwp-helper/releases/latest/download/snapwp-helper.zip --activate
     ```


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR fixes several formatting/styling issues in `getting-started.md`

- Fixed the formatting for the Backend Setup Installation Steps, and removed the comment to make the wp-cli command copy-pasteable.

- Clarified the internal link for the backend prerequisites.

- Fixed the image alignment in `Create an Environment File`.


## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->

Addresses QA + external feedback.

### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->

- Part of https://github.com/rtCamp/headless/issues/395
- Part of https://github.com/rtCamp/headless/issues/353


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->



## Additional Info
<!-- Please include any relevant logs, error output, etc -->



## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [x] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation accordingly.
