### PR TITLE
fix: Migrate fs to fsPromises in snapwp command

### DIFF
--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -111,28 +111,13 @@ const openEditor = ( filePath ) => {
 			'./examples/nextjs/starter/'
 		);
 
-		// Step 2: Copy the _entire_ `nextJsStarterPath` contents to the project directory.
-		const nextJSStarterEnvPath = path.join( nextJsStarterPath, '.env' );
-		await fs.rm( nextJSStarterEnvPath, { force: true } ); // Delete `.env` from starter if present, to prevent override of `.env`.
+		// @todo: Add interactive support to prompt for the env variable values one-at-a-time, create `.env` file using it in projectDirPath if --interactive is passed & skip `Step 2`.
 
-		console.log( '📂 Copying frontend folder to project directory...' );
-		await fs.cp( nextJsStarterPath, projectDirPath, {
-			recursive: true,
-			filter: ( source ) => {
-				const fileCheck = new RegExp(
-					`/${ nextJsStarterPath }/(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)$`
-				);
-				return ! fileCheck.test( source );
-			},
-		} );
+		// @todo: Create `.env` file directly with env_variables if --{specific_env_variable}={value} or --interactive is passed & skip `Step 2`.
 
-		// @todo: Add interactive support to prompt for the env variable values one-at-a-time, create `.env` file using it in projectDirPath if --interactive is passed & skip `Step 3`.
+		// @todo: Copy `.env` file to projectDirPath if file-path passed via --env_file={string or path} & skip `Step 2`.
 
-		// @todo: Create `.env` file directly with env_variables if --{specific_env_variable}={value} or --interactive is passed & skip `Step 3`.
-
-		// @todo: Copy `.env` file to projectDirPath if file-path passed via --env_file={string or path} & skip `Step 3`.
-
-		// Step 3: Check if there is an `.env` file in projectDirPath.
+		// Step 2: Check if there is an `.env` file in projectDirPath.
 		const envPath = path.join( projectDirPath, '.env' );
 
 		try {
@@ -199,6 +184,21 @@ const openEditor = ( filePath ) => {
 
 			process.exit( 1 );
 		}
+
+		// Step 3: Copy the _entire_ `nextJsStarterPath` contents to the project directory.
+		const nextJSStarterEnvPath = path.join( nextJsStarterPath, '.env' );
+		await fs.rm( nextJSStarterEnvPath, { force: true } ); // Delete `.env` from starter if present, to prevent override of `.env`.
+
+		console.log( '📂 Copying frontend folder to project directory...' );
+		await fs.cp( nextJsStarterPath, projectDirPath, {
+			recursive: true,
+			filter: ( source ) => {
+				const fileCheck = new RegExp(
+					`/${ nextJsStarterPath }/(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)$`
+				);
+				return ! fileCheck.test( source );
+			},
+		} );
 
 		// Step 4: Create .npmrc file in project directory if running via proxy registry.
 		if ( options.proxy ) {

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -88,7 +88,7 @@ const openEditor = ( filePath ) => {
 	try {
 		// Step 1: Prompt the user to input the directory where the project needs to be scaffolded.
 		const projectDir = await prompt(
-			'🫰 🫰 🫰  Thanks for using SnapWP! 🫰 🫰 🫰\n' +
+			'Thanks for using SnapWP!\n' +
 				'\nWhere would you like to create your new Headless WordPress frontend?\n' +
 				'Please enter a relative or absolute path: '
 		);
@@ -189,7 +189,7 @@ const openEditor = ( filePath ) => {
 		const nextJSStarterEnvPath = path.join( nextJsStarterPath, '.env' );
 		await fs.rm( nextJSStarterEnvPath, { force: true } ); // Delete `.env` from starter if present, to prevent override of `.env`.
 
-		console.log( '📂 Copying frontend folder to project directory...' );
+		console.log( 'Copying frontend folder to project directory...' );
 		await fs.cp( nextJsStarterPath, projectDirPath, {
 			recursive: true,
 			filter: ( source ) => {
@@ -230,14 +230,14 @@ const openEditor = ( filePath ) => {
 		console.log( '' );
 
 		console.log(
-			`✔️ Your project has been scaffolded at: ${ projectDirPath }.`
+			`Your project has been scaffolded at: ${ projectDirPath }.`
 		);
 
 		// New line for clarity.
 		console.log( '' );
 
 		console.log(
-			'🚀 To start your headless WordPress project, please run the following commands:'
+			'To start your headless WordPress project, please run the following commands:'
 		);
 		console.log( `cd ${ projectDirPath }` );
 		console.log( `npm install` );

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -116,19 +116,15 @@ const openEditor = ( filePath ) => {
 		await fs.rm( nextJSStarterEnvPath, { force: true } ); // Delete `.env` from starter if present, to prevent override of `.env`.
 
 		console.log( '📂 Copying frontend folder to project directory...' );
-		await fs.cp(
-			nextJsStarterPath,
-			projectDirPath,
-			{
-				recursive: true,
-				filter: ( source ) => {
-					const fileCheck = new RegExp(
-						`/${ nextJsStarterPath }/(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)$`
-					);
-					return ! fileCheck.test( source );
-				},
-			}
-		);
+		await fs.cp( nextJsStarterPath, projectDirPath, {
+			recursive: true,
+			filter: ( source ) => {
+				const fileCheck = new RegExp(
+					`/${ nextJsStarterPath }/(node_modules|package-lock\.json|\.env|\.next|next-env\.d\.ts|src\/__generated)$`
+				);
+				return ! fileCheck.test( source );
+			},
+		} );
 
 		// @todo: Add interactive support to prompt for the env variable values one-at-a-time, create `.env` file using it in projectDirPath if --interactive is passed & skip `Step 3`.
 
@@ -142,17 +138,17 @@ const openEditor = ( filePath ) => {
 		try {
 			await fs.access( envPath );
 		} catch ( error ) {
-			if ('ENOENT' !== error.code) {
-				console.error('Error:', error);
-				process.exit(1);
+			if ( 'ENOENT' !== error.code ) {
+				console.error( 'Error:', error );
+				process.exit( 1 );
 			}
 
 			await prompt(
 				`\nNo .env file found in "${ projectDirPath }". Please \n` +
-				'  1. Press any key to open a new .env file in your default editor,\n' +
-				'  2. Paste in the environment variables from your WordPress site, and update the values as needed. \n' +
-				'  3. Save and close the file to continue the installation. \n' +
-				'\n (For more information on configuring your .env file, see the SnapWP documentation.)' // @todo Update with the link to the documentation.
+					'  1. Press any key to open a new .env file in your default editor,\n' +
+					'  2. Paste in the environment variables from your WordPress site, and update the values as needed. \n' +
+					'  3. Save and close the file to continue the installation. \n' +
+					'\n (For more information on configuring your .env file, see the SnapWP documentation.)' // @todo Update with the link to the documentation.
 			);
 
 			/**
@@ -177,9 +173,9 @@ const openEditor = ( filePath ) => {
 				await fs.access( envPath );
 			} catch ( error ) {
 				// Throw error if .env file still does not exist.
-				if ('ENOENT' === error.code) {
+				if ( 'ENOENT' === error.code ) {
 					console.error(
-						`".env" still not found at "${envPath}". Please create an ".env" and try again.`
+						`".env" still not found at "${ envPath }". Please create an ".env" and try again.`
 					);
 					process.exit( 1 );
 				}


### PR DESCRIPTION
## What
- This PR will:
    - Fix fs.cp (copy) functionality in snapwp command by migrating `fs` to `fs/promises`.
    - Move the `.env` file generation from step 3 to step 2 in our command.
    - Remove emojis as they are not supported on Windows terminal.

### Related Issue(s):
- https://github.com/orgs/rtCamp/projects/141/views/14?pane=issue&itemId=96437176

## Testing Instructions
- Run the Development from `packages/cli/README.md`.

## Checklist

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation accordingly.
