### PR TITLE
ci: update examples workflow to use generated token

### DIFF
--- a/.github/workflows/pull_request_examples.yml
+++ b/.github/workflows/pull_request_examples.yml
@@ -183,7 +183,7 @@ jobs:
             - name: Checkout SnapWP Helper
               uses: actions/checkout@v4
               with:
-                  token: '${{ secrets.RTBOT_TOKEN }}'
+                  token: '${{ secrets.GITHUB_TOKEN }}'
                   repository: '${{ github.repository_owner }}/snapwp-helper'
                   path: snapwp-helper
                   ref: ${{ env.SNAPWP_HELPER_REF }}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
Changes from using a private token to the one generated in workflow as `snapwp-helper` is now public for checking out this repo in example build.



## Why
Previously we were using an internal token for checking out the repo, but now since it is public and we need forks running this workflow to be able to run the action, we change it to use the token from workflow itself.


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [ ] My code passes all lints (ESLint, tsc, prettier etc.).
-   [ ] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [ ] I have updated the project documentation accordingly.
