### PR TITLE
chore: Ensure `CoreTemplatePart` blocks are overloadable

### DIFF
--- a/docs/overloading-wp-behavior.md
+++ b/docs/overloading-wp-behavior.md
@@ -67,6 +67,87 @@ export default function Page() {
 
 Now, whenever a `core/paragraph` block is encountered, your `MyCustomParagraph` component will be used to render it. Any other blocks will use the default rendering unless you provide a custom component in `blockDefinitions`. Setting the value to `null` will use the [default block rendering](#default-block-rendering).
 
+---
+
+## Overloading Template Parts
+
+SnapWP allows you to customize **Template Parts**, such as headers, footers, etc, by mapping them to custom React components. This is useful for modifying the structure, design, or behavior of key site areas while keeping WordPress as the content source.
+
+> [!TIP] > **Template Parts** are reusable block structures in WordPress [Block Themes](https://wordpress.org/documentation/article/block-themes/).
+> Common examples include:
+>
+> -   The **Header** ( slug `"header"`)
+> -   The **Footer** ( slug `"footer"`)
+
+### 1. Identifying the Template Part
+
+Each **Template Part** has a unique `slug` (e.g., `"header"`, `"footer"`). You can retrieve this information via the attributes present in the props.
+
+### 2. Creating a Custom Component
+
+Create a new React component to modify the rendering of a specific Template Part.
+
+```tsx
+import React from 'react';
+import { BlockData, cn, getClassNamesFromString } from '@snapwp/core';
+
+export default function MyCustomFooter( {
+	renderedHtml,
+	attributes,
+}: BlockData ) {
+	const safeAttributes = attributes || {}; // Ensure attributes are not undefined.
+	const { templatePartTagName } = safeAttributes;
+
+	const TagName = templatePartTagName || 'footer';
+
+	// Extract class names from rendered HTML.
+	const classNamesFromString = renderedHtml
+		? getClassNamesFromString( renderedHtml )
+		: '';
+	const classNames = cn( classNamesFromString, 'custom-footer' );
+
+	return (
+		<TagName className={ classNames }>
+			<p className="footer-note">This is a custom footer!</p>
+		</TagName>
+	);
+}
+```
+
+### 3. Mapping the Template Part
+
+Map this custom component in the **SnapWP blockDefinitions** so it only applies to the `"footer"` template part.
+
+```tsx
+import { TemplateRenderer } from '@snapwp/next';
+import { EditorBlocksRenderer } from '@snapwp/blocks';
+import MyCustomFooter from '../../components/MyCustomFooter';
+
+const blockDefinitions = {
+	CoreTemplatePart: ( props ) => {
+		if ( props.attributes.slug === 'footer' ) {
+			return <MyCustomFooter { ...props } />;
+		}
+		return null; // Default rendering for other template parts.
+	},
+};
+
+export default function Page() {
+	return (
+		<TemplateRenderer>
+			{ ( editorBlocks ) => (
+				<EditorBlocksRenderer
+					editorBlocks={ editorBlocks }
+					blockDefinitions={ blockDefinitions }
+				/>
+			) }
+		</TemplateRenderer>
+	);
+}
+```
+
+---
+
 ## Creating Custom Frontend Routes
 
 This tutorial explains how to create custom frontend routes in your SnapWP-powered Next.js application using the App Router.

--- a/packages/query/src/fragments/core-template-part.graphql
+++ b/packages/query/src/fragments/core-template-part.graphql
@@ -1,6 +1,9 @@
 fragment CoreTemplatePartFrag on CoreTemplatePart {
 	renderedHtml
 	attributes {
+		className
+		slug
 		templatePartTagName: tagName
+		theme
 	}
 }


### PR DESCRIPTION
## What

This PR enhances the overloading capabilities for template parts in SnapWP.
This PR ensures overloading of Template-parts by introducing attributes such as `classname`, `slug` and `theme`. This PR also updates the `docs/overloading-wp-behavior` to add a section on how to overload a template part.

## Why

Previously, only `templatePartTagName` was available, limiting the ability to precisely target and overload template parts.
By including `slug`, `className`, and `theme`, users can now target specific template parts more granularly, enabling greater customization.
The new docs provide clear guidance on how to implement overloading using these attributes.

### Related Issue(s):
- Part of [Task: Ensure that Block Patterns, Template Parts, and Templates are overloadable](https://github.com/rtCamp/headless/issues/398)

## How

#### GraphQL Fragment Update:
- Modified the existing fragment to fetch `slug`, `className`, and `theme` for `core/template-part` blocks.

#### Documentation Update:
- Added a new section on Overloading Template Parts, explaining how to use the new attributes to override specific parts (e.g., footer, header).


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->

#### Before Overloading Footer component:
<img width="1280" alt="Screenshot 2025-02-07 at 12 53 04 PM" src="https://github.com/user-attachments/assets/17b90e82-9fa5-4784-8c6d-6b33491bec4d" />

#### After Overloading Footer Template Part:
<img width="1280" alt="Screenshot 2025-02-07 at 12 55 17 PM" src="https://github.com/user-attachments/assets/d8d8cb0d-3597-4950-a028-89ed7e41734b" />

## Additional Info
<!-- Please include any relevant logs, error output, etc -->
- Added undefined check for attributes getting passed to custom component is mentioned in docs.

## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [ ] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation accordingly.
