### PR TITLE
docs: add copy `.env.example` to DEVELOPMENT.md setup steps

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,31 +64,31 @@ To set up locally, clone the repository and navigate to the `frontend` subdirect
 
 ### Setup
 
-1. Copy the example environment file:
+1. Copy the example environment file to `.env` and update the values as needed.
 
     ```bash
     cp .env.example .env
     ```
 
-2. Use node version in .nvmrc
+2. Use the node version defined in .nvmrc.
 
     ```bash
     nvm use
     ```
 
-3. Install the NPM dependencies:
+3. Install the NPM dependencies.
 
     ```bash
     npm install
     ```
 
-4. Build the packages:
+4. Build the packages.
 
     ```bash
     npm run build
     ```
 
-5. Publish packages locally:
+5. Publish packages locally.
 
     ```bash
     npm run publish:local

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,25 +64,31 @@ To set up locally, clone the repository and navigate to the `frontend` subdirect
 
 ### Setup
 
-1. Use node version in .nvmrc
+1. Copy the example environment file:
+
+    ```bash
+    cp .env.example .env
+    ```
+
+2. Use node version in .nvmrc
 
     ```bash
     nvm use
     ```
 
-2. Install the NPM dependencies:
+3. Install the NPM dependencies:
 
     ```bash
     npm install
     ```
 
-3. Build the packages:
+4. Build the packages:
 
     ```bash
     npm run build
     ```
 
-4. Publish packages locally:
+5. Publish packages locally:
 
     ```bash
     npm run publish:local


### PR DESCRIPTION

## What
Add missing `.env` setup step to development documentation to ensure proper environment configuration.

## Why
Currently, the development setup documentation doesn't include the crucial step of copying `.env.example` to `.env`. This can lead to confusion and setup issues for new contributors since various build and development processes may depend on environment variables.

### Related Issue(s):
Fixes a [draft issue](https://github.com/orgs/rtCamp/projects/141/views/14?pane=issue&itemId=97131680)

## How
- Added a new step at the beginning of the setup instructions in `DEVELOPMENT.md`
- Included the command `cp .env.example .env` with proper formatting
- Reordered existing steps to ensure environment setup occurs before other installation steps

## Testing Instructions
1. Clone the repository fresh
2. Follow the updated setup instructions in `DEVELOPMENT.md`
3. Verify that all steps work as expected, particularly:
   - The `.env` file is created from `.env.example`
   - Subsequent setup steps complete successfully

## Screenshots
N/A - Documentation change only

## Additional Info
N/A

## Checklist
- [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md)
- [x] My code is tested to the best of my abilities
- [x] My code passes all lints (ESLint, tsc, prettier etc.)
- [x] My code has detailed inline documentation
- [ ] I have added unit tests to verify the code works as intended
- [x] I have updated the project documentation accordingly