### PR TITLE
dev: enable `noUncheckedIndexedAccess` and remediate exposed issues

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -12,7 +12,7 @@
 		"noImplicitOverride": true,
 		"noImplicitReturns": true,
 		"noPropertyAccessFromIndexSignature": false, // @todo Enable this.
-		"noUncheckedIndexedAccess": false, // @todo Enable this.
+		"noUncheckedIndexedAccess": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"strictFunctionTypes": true,

--- a/packages/blocks/src/block-manager/index.tsx
+++ b/packages/blocks/src/block-manager/index.tsx
@@ -52,8 +52,10 @@ export default class BlockManager {
 			BlockManager.blockDefinitions[ node.type ] !== undefined &&
 			BlockManager.blockDefinitions[ node.type ] !== null
 		) {
+			// @ts-ignore -- Block definitions are checked for null/undefined.
 			node.renderer = BlockManager.blockDefinitions[ node.type ];
 		} else {
+			// @ts-ignore -- @todo remove when types are fixed.
 			node.renderer = BlockManager.blockDefinitions.default;
 			node.children = null;
 		}

--- a/packages/blocks/src/blocks/core-image.tsx
+++ b/packages/blocks/src/blocks/core-image.tsx
@@ -333,6 +333,11 @@ const extractInteractivityAttributesForElement = (
 	while ( ( match = regex.exec( renderedHtml ) ) !== null ) {
 		const [ , attributes ] = match;
 		let dataMatch;
+
+		if ( ! attributes ) {
+			continue;
+		}
+
 		while (
 			( dataMatch = dataAttributesRegex.exec( attributes ) ) !== null
 		) {
@@ -368,6 +373,11 @@ const extractAriaAttributesForElement = (
 	while ( ( match = regex.exec( renderedHtml ) ) !== null ) {
 		const [ , attributes ] = match;
 		let dataMatch;
+
+		if ( ! attributes ) {
+			continue;
+		}
+
 		while (
 			( dataMatch = dataAttributesRegex.exec( attributes ) ) !== null
 		) {

--- a/packages/core/src/utils/get-style-object-from-string.ts
+++ b/packages/core/src/utils/get-style-object-from-string.ts
@@ -9,10 +9,11 @@ import { Logger } from '@/logger';
  *
  * @internal
  */
-function formatStringToCamelCase( str: string ) {
+function formatStringToCamelCase( str: string ): string {
 	const splitted = str.split( '-' ).filter( ( word ) => !! word );
+
 	if ( splitted.length === 1 ) {
-		return splitted[ 0 ];
+		return splitted[ 0 ]!;
 	}
 
 	return (
@@ -20,7 +21,7 @@ function formatStringToCamelCase( str: string ) {
 		splitted
 			.slice( 1 )
 			.map( ( word ) => {
-				return word[ 0 ].toUpperCase() + word.slice( 1 );
+				return word[ 0 ]!.toUpperCase() + word.slice( 1 );
 			} )
 			.join( '' )
 	);

--- a/packages/next/src/components/image.tsx
+++ b/packages/next/src/components/image.tsx
@@ -8,7 +8,6 @@ import { cn } from '@snapwp/core';
 import { getConfig } from '@snapwp/core/config';
 
 interface MediaItem {
-	id: string;
 	altText?: string | null;
 	mediaDetails: {
 		width: number | undefined;

--- a/packages/next/src/components/link.tsx
+++ b/packages/next/src/components/link.tsx
@@ -8,7 +8,7 @@ import { getConfig } from '@snapwp/core/config';
 import NextLink, { type LinkProps } from 'next/link';
 
 interface LinkInterface {
-	href: string;
+	href?: string;
 	style?: CSSProperties | undefined;
 	className?: string | undefined;
 }
@@ -35,12 +35,14 @@ export default function Link( {
 > ) {
 	const { homeUrl, nextUrl, graphqlEndpoint } = getConfig();
 
-	const internalUri = replaceHostUrl(
-		href,
-		homeUrl,
-		nextUrl
-		// @todo: Remove replace when the graphql endpoint is removed from the pagination links.
-	)?.replace( `/${ graphqlEndpoint }`, '' );
+	const internalUri = href
+		? replaceHostUrl(
+				href,
+				homeUrl,
+				nextUrl
+				// @todo: Remove replace when the graphql endpoint is removed from the pagination links.
+		  )?.replace( `/${ graphqlEndpoint }`, '' )
+		: '';
 
 	// @todo replace internalUri?.startsWith conditional check with something more robust that will incorporate both frontend/backend domain & anything in the list of allowed images domain in the config (ref: https://github.com/rtCamp/headless/pull/241#discussion_r1824274200). TBD after https://github.com/rtCamp/headless/issues/218.
 	if (


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR enables [`noUncheckedIndexedAccess`](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess) and attempts to remediate the exposed smells



## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->


### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->

Part of https://github.com/rtCamp/headless/issues/317



## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->

See the commit history. Each remediation occurs in its own commit.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->



## Additional Info
<!-- Please include any relevant logs, error output, etc -->

## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [x] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [x] I have added a changeset for this PR using `npm run changeset`.
