### PR TITLE
docs: clarify `npm run dev`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,7 +64,7 @@ To set up locally, clone the repository and navigate to the `frontend` subdirect
 
 ### Setup
 
-1. Copy the example environment file to `.env` and update the values as needed.
+1. Copy the example environment file to `.env` and update the [values as needed](./docs/config-api.md#env-variables)
 
     ```bash
     cp .env.example .env
@@ -82,22 +82,25 @@ To set up locally, clone the repository and navigate to the `frontend` subdirect
     npm install
     ```
 
-4. Choose ONE of the following options:
-
-    **Option A: Build and Run in Development Mode**
+4. Build the packages locally.
 
     ```bash
     npm run build
+    ```
+
+   At this point the libraries should be ready to use in any of the projects in the `examples/` directory.
+
+5. (Optional) Start the packages in watch mode.
+
+    ```bash
     npm run dev
     ```
 
-    **Option B: Publish Packages Locally**
+    Alternatively, you can publish the packages locally using Verdaccio:
 
     ```bash
     npm run publish:local
     ```
-
-The `dev` command runs the packages in watch mode, but requires either a build step or local publishing first to work properly.
 
 ## Code Contributions (Pull Requests)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,7 +88,7 @@ To set up locally, clone the repository and navigate to the `frontend` subdirect
     npm run build
     ```
 
-   At this point the libraries should be ready to use in any of the projects in the `examples/` directory.
+    At this point the libraries should be ready to use in any of the projects in the `examples/` directory.
 
 5. (Optional) Start the packages in watch mode.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,23 +82,22 @@ To set up locally, clone the repository and navigate to the `frontend` subdirect
     npm install
     ```
 
-4. Build the packages.
+4. Choose ONE of the following options:
+
+    **Option A: Build and Run in Development Mode**
 
     ```bash
     npm run build
+    npm run dev
     ```
 
-5. Publish packages locally.
+    **Option B: Publish Packages Locally**
 
     ```bash
     npm run publish:local
     ```
 
-Alternatively, you could build the packages in watch mode:
-
-```bash
-npm run dev
-```
+The `dev` command runs the packages in watch mode, but requires either a build step or local publishing first to work properly.
 
 ## Code Contributions (Pull Requests)
 


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->
## What
Improve setup instructions to clarify build prerequisites for development mode

## Why
The current setup instructions don't clearly indicate that `npm run dev` requires either a build step or local package publishing to work properly. This can lead to confusion and setup failures for new developers.

### Related Issue(s):
<!-- Add issue number if one exists -->

## How
- Restructured setup instructions to show two clear paths:
  1. Build + Dev mode
  2. Local publishing
- Removed ambiguous "alternatively" phrasing
- Added explicit grouping of related commands
- Maintained all existing setup steps while improving clarity

## Testing Instructions
1. Clone the repository
2. Follow new setup instructions using either path:
   
   **Path A:**
   ```bash
   npm install
   npm run build
   npm run dev
   ```
   
   **Path B:**
   ```bash
   npm install
   npm run publish:local
   ```
3. Verify development environment starts successfully

## Screenshots
<!-- Before/after screenshots of the documentation changes if relevant -->

## Additional Info
This change is purely documentation-focused and doesn't modify any code functionality.

## Checklist
-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.