### PR TITLE
fix: links breaking when there is no trailing slash in `NEXT_PUBLIC_URL`

### DIFF
--- a/.changeset/nice-bears-notice.md
+++ b/.changeset/nice-bears-notice.md
@@ -1,0 +1,5 @@
+---
+"@snapwp/core": patch
+---
+
+fix: Ensure `homeUrl` and `nextUrl` do not have a trailing slash in `SnapWPConfigManager.normalizeConfig`

--- a/packages/core/src/config/snapwp-config-manager.ts
+++ b/packages/core/src/config/snapwp-config-manager.ts
@@ -220,6 +220,7 @@ class SnapWPConfigManager {
 				if ( cfg[ key ] === undefined ) {
 					delete cfg[ key ];
 				} else if (
+					// This should probably be moved into the schema as a sanitize callback.
 					( key === 'homeUrl' || key === 'nextUrl' ) &&
 					typeof cfg[ key ] === 'string'
 				) {

--- a/packages/core/src/config/snapwp-config-manager.ts
+++ b/packages/core/src/config/snapwp-config-manager.ts
@@ -220,7 +220,7 @@ class SnapWPConfigManager {
 				if ( cfg[ key ] === undefined ) {
 					delete cfg[ key ];
 				} else if (
-					// This should probably be moved into the schema as a sanitize callback.
+					// @todo this should probably be moved into the schema as a sanitize callback.
 					( key === 'homeUrl' || key === 'nextUrl' ) &&
 					typeof cfg[ key ] === 'string'
 				) {

--- a/packages/core/src/config/snapwp-config-manager.ts
+++ b/packages/core/src/config/snapwp-config-manager.ts
@@ -219,6 +219,16 @@ class SnapWPConfigManager {
 			( key: keyof T ) => {
 				if ( cfg[ key ] === undefined ) {
 					delete cfg[ key ];
+				} else if (
+					( key === 'homeUrl' || key === 'nextUrl' ) &&
+					typeof cfg[ key ] === 'string'
+				) {
+					cfg[ key ] = ( cfg[ key ] as string ).endsWith( '/' )
+						? ( ( cfg[ key ] as string ).slice(
+								0,
+								-1
+						  ) as T[ keyof T ] )
+						: cfg[ key ];
 				}
 			}
 		);

--- a/packages/core/src/config/tests/snapwp-config-manager.test.ts
+++ b/packages/core/src/config/tests/snapwp-config-manager.test.ts
@@ -199,4 +199,15 @@ describe( 'SnapWPConfigManager functions', () => {
 			'`uploadsDirectory` should start with a forward slash.'
 		);
 	} );
+
+	it( 'should correctly normalize URLs by removing trailing slashes', () => {
+		process.env.NEXT_PUBLIC_URL = 'https://localhost:3000/';
+		process.env.NEXT_PUBLIC_WORDPRESS_URL =
+			'https://wordpress.example.com/';
+
+		const config = getConfig();
+
+		expect( config.nextUrl ).toBe( 'https://localhost:3000' );
+		expect( config.homeUrl ).toBe( 'https://wordpress.example.com' );
+	} );
 } );

--- a/packages/core/src/utils/replace-host-url.ts
+++ b/packages/core/src/utils/replace-host-url.ts
@@ -16,6 +16,5 @@ export default function replaceHostUrl(
 	if ( url && hostUrl && url.startsWith( hostUrl ) ) {
 		return url.replace( hostUrl, newHostUrl );
 	}
-
 	return url;
 }

--- a/packages/core/src/utils/replace-host-url.ts
+++ b/packages/core/src/utils/replace-host-url.ts
@@ -13,8 +13,20 @@ export default function replaceHostUrl(
 	hostUrl: string,
 	newHostUrl: string
 ) {
-	if ( url && hostUrl && url.startsWith( hostUrl ) ) {
+	if ( ! url || ! hostUrl ) {
+		return url;
+	}
+
+	if ( ! hostUrl.endsWith( '/' ) ) {
+		hostUrl += '/';
+	}
+	if ( ! newHostUrl.endsWith( '/' ) ) {
+		newHostUrl += '/';
+	}
+
+	if ( url.startsWith( hostUrl ) ) {
 		return url.replace( hostUrl, newHostUrl );
 	}
+
 	return url;
 }

--- a/packages/core/src/utils/replace-host-url.ts
+++ b/packages/core/src/utils/replace-host-url.ts
@@ -13,18 +13,7 @@ export default function replaceHostUrl(
 	hostUrl: string,
 	newHostUrl: string
 ) {
-	if ( ! url || ! hostUrl ) {
-		return url;
-	}
-
-	if ( ! hostUrl.endsWith( '/' ) ) {
-		hostUrl += '/';
-	}
-	if ( ! newHostUrl.endsWith( '/' ) ) {
-		newHostUrl += '/';
-	}
-
-	if ( url.startsWith( hostUrl ) ) {
+	if ( url && hostUrl && url.startsWith( hostUrl ) ) {
 		return url.replace( hostUrl, newHostUrl );
 	}
 


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR fixes the bug where links would break when there is no trailing slash in `NEXT_PUBLIC_URL` or `NEXT_PUBLIC_WORDPRESS_URL`

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
Links would not work.

### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
`normalizeConfig` is updated to remove trailing slashes from `homeUrl` and `nextUrl`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->


## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->


## Additional Info
<!-- Please include any relevant logs, error output, etc -->


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [x] I have added a changeset for this PR using `npm run changeset`.
