### PR TITLE
chore: cleanup ESLint rulesets

### DIFF
--- a/.changeset/loud-carrots-repair.md
+++ b/.changeset/loud-carrots-repair.md
@@ -1,0 +1,5 @@
+---
+"@snapwp/eslint-config": minor
+---
+
+refactor!: Remove `overrides` from `eslint-config` ruleset

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,6 +5,7 @@ module.exports = {
 	},
 	extends: '@snapwp/eslint-config',
 	parser: '@typescript-eslint/parser',
+	plugins: [ '@typescript-eslint', 'jest', '@stylistic/jsx' ],
 	ignorePatterns: [
 		'**/__generated/',
 		'**/.eslintrc.cjs',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,6 +4,7 @@ module.exports = {
 		node: true,
 	},
 	extends: '@snapwp/eslint-config',
+	parser: '@typescript-eslint/parser',
 	ignorePatterns: [
 		'**/__generated/',
 		'**/.eslintrc.cjs',
@@ -22,6 +23,43 @@ module.exports = {
 	},
 	settings: {
 		'import/resolver': require.resolve( './config/import-resolver.cjs' ),
+	},
+	rules: {
+		// Restrict usage of "bad" libraries.
+		'@typescript-eslint/no-restricted-imports': [
+			'error',
+			'classnames',
+			'lodash',
+		],
+		'no-restricted-imports': [
+			'error',
+			{
+				paths: [
+					{
+						name: 'classnames',
+						message:
+							"Please use `clsx` instead. It's a lighter and faster drop-in replacement for `classnames`.",
+					},
+					{
+						name: 'lodash',
+						message: 'Please use native functionality instead.',
+					},
+				],
+			},
+		],
+
+		// Restricted syntax should error, not warn.
+		'no-restricted-syntax': [ 'error' ],
+
+		// Import rules.
+		'import/default': 'error',
+		'import/named': 'error',
+
+		// Jest rules.
+		'jest/expect-expect': 'off',
+
+		// Turn of JSdoc types and use TypeScript types instead.
+		'jsdoc/no-types': [ 'off' ],
 	},
 	overrides: [
 		{

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
 	},
 	extends: '@snapwp/eslint-config',
 	parser: '@typescript-eslint/parser',
-	plugins: [ '@stylistic/jsx', '@typescript-eslint', 'jest' ],
+	plugins: [ '@typescript-eslint', 'jest' ],
 	ignorePatterns: [
 		'**/__generated/',
 		'**/.eslintrc.cjs',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
 	},
 	extends: '@snapwp/eslint-config',
 	parser: '@typescript-eslint/parser',
-	plugins: [ '@typescript-eslint', 'jest', '@stylistic/jsx' ],
+	plugins: [ '@stylistic/jsx', '@typescript-eslint', 'jest' ],
 	ignorePatterns: [
 		'**/__generated/',
 		'**/.eslintrc.cjs',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,16 +5,17 @@ module.exports = {
 	},
 	extends: '@snapwp/eslint-config',
 	ignorePatterns: [
-		'**/node_modules/**',
-		'**/dist/**',
+		'**/__generated/',
+		'**/.eslintrc.cjs',
+		'**/config/*.js',
 		'**/dist-types/**',
-		'out/**',
-		'data/**',
+		'**/dist',
+		'**/dist/**',
+		'**/node_modules/**',
 		'assets/**/*.js',
 		'coverage/**',
-		'**/config/*.js',
-		'**/dist',
-		'**/__generated/',
+		'data/**',
+		'out/**',
 	],
 	globals: {
 		globalThis: 'readonly',
@@ -23,7 +24,32 @@ module.exports = {
 		'import/resolver': require.resolve( './config/import-resolver.cjs' ),
 	},
 	overrides: [
-		// Disable n/no-process-env for codegen.ts file
+		{
+			files: '**/*.test.ts',
+			env: {
+				jest: true,
+			},
+		},
+		{
+			files: [ '**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx' ],
+			// Mandate doc block for arrow functions, class declarations, class expressions, function expressions, and method definition.
+			rules: {
+				'jsdoc/require-jsdoc': [
+					'error',
+					{
+						require: {
+							ArrowFunctionExpression: true,
+							ClassDeclaration: true,
+							ClassExpression: true,
+							FunctionExpression: true,
+							MethodDefinition: true,
+						},
+					},
+				],
+				'import/default': [ 'off' ],
+			},
+		},
+		// Disable n/no-process-env for `codegen.ts` file.
 		{
 			files: [ '**/codegen.ts', '**/*.test.*', '**/jest.setup.js' ],
 			rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
 				"@changesets/changelog-github": "^0.5.0",
 				"@changesets/cli": "^2.27.12",
 				"@playwright/test": "^1.50.0",
-				"@stylistic/eslint-plugin-jsx": "^3.1.0",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@testing-library/react": "^16.2.0",
 				"@types/jest": "^29.5.14",
@@ -4879,65 +4878,6 @@
 		"node_modules/@snapwp/types": {
 			"resolved": "packages/types",
 			"link": true
-		},
-		"node_modules/@stylistic/eslint-plugin-jsx": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-3.1.0.tgz",
-			"integrity": "sha512-+4SYALAM+l6OH6ARGUJ5h0coQBq7Y1QQVS8JbVFPZWuxdXVLTTwpj8qCnpW0afzyS/sBu4MaPDdGnGL16KebAQ==",
-			"dev": true,
-			"dependencies": {
-				"eslint-visitor-keys": "^4.2.0",
-				"espree": "^10.3.0",
-				"estraverse": "^5.3.0",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"peerDependencies": {
-				"eslint": ">=8.40.0"
-			}
-		},
-		"node_modules/@stylistic/eslint-plugin-jsx/node_modules/eslint-visitor-keys": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-			"dev": true,
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/@stylistic/eslint-plugin-jsx/node_modules/espree": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-			"integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
-			"dev": true,
-			"dependencies": {
-				"acorn": "^8.14.0",
-				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^4.2.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/@stylistic/eslint-plugin-jsx/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
 		},
 		"node_modules/@swc/counter": {
 			"version": "0.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@changesets/changelog-github": "^0.5.0",
 				"@changesets/cli": "^2.27.12",
 				"@playwright/test": "^1.50.0",
+				"@stylistic/eslint-plugin-jsx": "^3.1.0",
 				"@testing-library/jest-dom": "^6.6.3",
 				"@testing-library/react": "^16.2.0",
 				"@types/jest": "^29.5.14",
@@ -28,6 +29,7 @@
 				"@types/react-dom": "^19.0.3",
 				"babel-jest": "^29.7.0",
 				"eslint": "^8.57.1",
+				"eslint-plugin-eslint-comments": "^3.2.0",
 				"jest": "^29.7.0",
 				"jest-environment-jsdom": "^29.7.0",
 				"npm-run-all": "^4.1.5",
@@ -4876,6 +4878,65 @@
 			"resolved": "packages/types",
 			"link": true
 		},
+		"node_modules/@stylistic/eslint-plugin-jsx": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-3.1.0.tgz",
+			"integrity": "sha512-+4SYALAM+l6OH6ARGUJ5h0coQBq7Y1QQVS8JbVFPZWuxdXVLTTwpj8qCnpW0afzyS/sBu4MaPDdGnGL16KebAQ==",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^4.2.0",
+				"espree": "^10.3.0",
+				"estraverse": "^5.3.0",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-jsx/node_modules/eslint-visitor-keys": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-jsx/node_modules/espree": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+			"integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.14.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin-jsx/node_modules/picomatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/@swc/counter": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -8535,6 +8596,34 @@
 			},
 			"peerDependencies": {
 				"eslint": ">=8"
+			}
+		},
+		"node_modules/eslint-plugin-eslint-comments": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+			"integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "^1.0.5",
+				"ignore": "^5.0.5"
+			},
+			"engines": {
+				"node": ">=6.5.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=4.19.1"
+			}
+		},
+		"node_modules/eslint-plugin-eslint-comments/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/eslint-plugin-import": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
 				"@types/node": "^22.12.0",
 				"@types/react": "^19.0.8",
 				"@types/react-dom": "^19.0.3",
+				"@typescript-eslint/eslint-plugin": "^6.4.1",
+				"@typescript-eslint/parser": "^6.0.0",
 				"babel-jest": "^29.7.0",
 				"eslint": "^8.57.1",
 				"eslint-plugin-eslint-comments": "^3.2.0",
@@ -17266,8 +17268,6 @@
 			"version": "0.1.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "^6.4.1",
-				"@typescript-eslint/parser": "^6.0.0",
 				"@wordpress/eslint-plugin": "^19.2.0",
 				"eslint-import-resolver-typescript": "^3.6.1",
 				"eslint-plugin-jsdoc": "^48.9.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,9 @@
 		"resolve-tspaths": "^0.8.23",
 		"ts-jest": "^29.2.5",
 		"tsc-watch": "^6.3.0",
-		"typescript": ">=4.3.5 <5.4.0"
+		"typescript": ">=4.3.5 <5.4.0",
+		"@stylistic/eslint-plugin-jsx": "^3.1.0",
+		"eslint-plugin-eslint-comments": "^3.2.0"
 	},
 	"dependencies": {
 		"react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
 		"ts-jest": "^29.2.5",
 		"tsc-watch": "^6.3.0",
 		"typescript": ">=4.3.5 <5.4.0",
+		"@typescript-eslint/eslint-plugin": "^6.4.1",
+		"@typescript-eslint/parser": "^6.0.0",
 		"@stylistic/eslint-plugin-jsx": "^3.1.0",
 		"eslint-plugin-eslint-comments": "^3.2.0"
 	},

--- a/package.json
+++ b/package.json
@@ -87,8 +87,7 @@
 		"tsc-watch": "^6.3.0",
 		"typescript": ">=4.3.5 <5.4.0",
 		"@typescript-eslint/eslint-plugin": "^6.4.1",
-		"@typescript-eslint/parser": "^6.0.0",
-		"eslint-plugin-eslint-comments": "^3.2.0"
+		"@typescript-eslint/parser": "^6.0.0"
 	},
 	"dependencies": {
 		"react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
 		"typescript": ">=4.3.5 <5.4.0",
 		"@typescript-eslint/eslint-plugin": "^6.4.1",
 		"@typescript-eslint/parser": "^6.0.0",
-		"@stylistic/eslint-plugin-jsx": "^3.1.0",
 		"eslint-plugin-eslint-comments": "^3.2.0"
 	},
 	"dependencies": {

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -11,34 +11,6 @@ module.exports = {
 		'plugin:jsdoc/recommended-typescript',
 		'plugin:import/typescript',
 	],
-	ignorePatterns: [ '**/config/*.js', '**/dist' ],
-	settings: {},
-	overrides: [
-		{
-			files: '**/*.test.ts',
-			env: {
-				jest: true,
-			},
-		},
-		{
-			files: [ '**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx' ],
-			rules: {
-				'jsdoc/require-jsdoc': [
-					'error',
-					{
-						require: {
-							ArrowFunctionExpression: true,
-							ClassDeclaration: true,
-							ClassExpression: true,
-							FunctionExpression: true,
-							MethodDefinition: true,
-						},
-					},
-				],
-				'import/default': [ 'off' ],
-			},
-		},
-	],
 	rules: {
 		'n/no-process-env': [ 'error' ],
 	},

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -4,11 +4,11 @@ module.exports = {
 		browser: true,
 		es6: true,
 	},
-	plugins: [ '@wordpress/eslint-plugin', 'import', 'n', 'jsdoc' ],
+	plugins: [ '@wordpress/eslint-plugin', 'import', 'jsdoc', 'n' ],
 	extends: [
 		'plugin:@wordpress/eslint-plugin/recommended',
-		'plugin:jsdoc/recommended-typescript',
 		'plugin:import/typescript',
+		'plugin:jsdoc/recommended-typescript',
 	],
 	rules: {
 		'n/no-process-env': [ 'error' ],

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -4,15 +4,7 @@ module.exports = {
 		browser: true,
 		es6: true,
 	},
-	plugins: [
-		'@typescript-eslint',
-		'@wordpress/eslint-plugin',
-		'import',
-		'n',
-		'jest',
-		'jsdoc',
-		'@stylistic/jsx',
-	],
+	plugins: [ '@wordpress/eslint-plugin', 'import', 'n', 'jsdoc' ],
 	extends: [
 		'plugin:@wordpress/eslint-plugin/recommended',
 		'plugin:jsdoc/recommended-typescript',

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -5,7 +5,15 @@ module.exports = {
 		es6: true,
 	},
 	parser: '@typescript-eslint/parser',
-	plugins: [ '@wordpress/eslint-plugin', 'jsdoc', 'import', 'n' ],
+	plugins: [
+		'@typescript-eslint',
+		'@wordpress/eslint-plugin',
+		'import',
+		'n',
+		'jest',
+		'jsdoc',
+		'@stylistic/jsx',
+	],
 	extends: [
 		'plugin:@wordpress/eslint-plugin/recommended',
 		'plugin:jsdoc/recommended-typescript',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -7,8 +7,6 @@
 	"exports": "./index.js",
 	"dependencies": {
 		"@wordpress/eslint-plugin": "^19.2.0",
-		"@typescript-eslint/eslint-plugin": "^6.4.1",
-		"@typescript-eslint/parser": "^6.0.0",
 		"eslint-plugin-n": "^17.10.2",
 		"eslint-import-resolver-typescript": "^3.6.1",
 		"eslint-plugin-jsdoc": "^48.9.2"


### PR DESCRIPTION
## What
- This PR reformats eslint rulesets i.e. migrate configurations to their respective places & adds following plugins + rulesets:

### `.eslintrc.cjs` File

#### parser
- `@typescript-eslint/parser` parser migrated from `packages/eslint-config/index.js` as it is not required in public package because JavaScript files are shipped. (ref: https://github.com/rtCamp/snapwp/pull/60#issuecomment-2654116722)

#### ignorePatterns
- ignorePatterns are sorted ascending.

#### rules

##### [@typescript-eslint/no-restricted-imports](https://typescript-eslint.io/rules/no-restricted-imports/)
- Restricts use of `classnames` & `lodash` imports in TypeScript files.

##### [import/default](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md)
- If a default import is requested, this rule will report if there is no default export in the imported module.

##### [import/named](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/named.md)
- Verifies that all named imports are part of the set of named exports in the referenced module.

##### [jest/expect-expect](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/expect-expect.md)
- There can be test cases that might not have expect call made.

##### [jsdoc/no-types](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/.README/rules/no-types.md)
- Allows adding type-definitions to `@param` & `@return`

##### [no-restricted-imports](https://eslint.org/docs/latest/rules/no-restricted-imports)
- Restricts use of `classnames` & `lodash` imports in JavaScript files.

##### [no-restricted-syntax](https://eslint.org/docs/latest/rules/no-restricted-syntax)
- Disallows specified syntax (Currently no syntax is restricted but as the project grows certain restrictions will be added as required in future versions)

#### overrides
- Overrides are migrated from `packages/eslint-config/index.js`, no additional override is added.

### `packages/eslint-config/index.js` File

#### plugins

The following new plugins have been added that will be used to make strict rules in upcoming PRs:

- [@typescript-eslint](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin)
- [jest](https://www.npmjs.com/package/eslint-plugin-jest)
- [@stylistic/jsx](https://www.npmjs.com/package/@stylistic/eslint-plugin-jsx)


## Related Issue(s):
- https://github.com/rtCamp/headless/issues/250

## Testing Instructions
- Run `npm install` && `npm run lint`.


## Additional Info
- This PR is a breakdown of https://github.com/rtCamp/snapwp/pull/61. As we are just migrating configs from one file to another & adding rulesets that the code is current following, we won't be getting any eslint errors in this PR.
- We will raise ruleset (causing eslint errors) wise PRs, along with their fixes.

## Checklist

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
