### PR TITLE
refactor!: move ESLint overrides from package to local ruleset

### DIFF
--- a/.changeset/loud-carrots-repair.md
+++ b/.changeset/loud-carrots-repair.md
@@ -1,0 +1,5 @@
+---
+"@snapwp/eslint-config": minor
+---
+
+refactor!: Remove `overrides` from `eslint-config` ruleset

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,6 +4,7 @@ module.exports = {
 		node: true,
 	},
 	extends: '@snapwp/eslint-config',
+	parser: '@typescript-eslint/parser',
 	ignorePatterns: [
 		'**/__generated/',
 		'**/.eslintrc.cjs',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,16 +5,17 @@ module.exports = {
 	},
 	extends: '@snapwp/eslint-config',
 	ignorePatterns: [
-		'**/node_modules/**',
-		'**/dist/**',
+		'**/__generated/',
+		'**/.eslintrc.cjs',
+		'**/config/*.js',
 		'**/dist-types/**',
-		'out/**',
-		'data/**',
+		'**/dist',
+		'**/dist/**',
+		'**/node_modules/**',
 		'assets/**/*.js',
 		'coverage/**',
-		'**/config/*.js',
-		'**/dist',
-		'**/__generated/',
+		'data/**',
+		'out/**',
 	],
 	globals: {
 		globalThis: 'readonly',
@@ -23,7 +24,32 @@ module.exports = {
 		'import/resolver': require.resolve( './config/import-resolver.cjs' ),
 	},
 	overrides: [
-		// Disable n/no-process-env for codegen.ts file
+		{
+			files: '**/*.test.ts',
+			env: {
+				jest: true,
+			},
+		},
+		{
+			files: [ '**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx' ],
+			// Mandate doc block for arrow functions, class declarations, class expressions, function expressions, and method definition.
+			rules: {
+				'jsdoc/require-jsdoc': [
+					'error',
+					{
+						require: {
+							ArrowFunctionExpression: true,
+							ClassDeclaration: true,
+							ClassExpression: true,
+							FunctionExpression: true,
+							MethodDefinition: true,
+						},
+					},
+				],
+				'import/default': [ 'off' ],
+			},
+		},
+		// Disable n/no-process-env for `codegen.ts` file.
 		{
 			files: [ '**/codegen.ts', '**/*.test.*', '**/jest.setup.js' ],
 			rules: {

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -11,34 +11,6 @@ module.exports = {
 		'plugin:jsdoc/recommended-typescript',
 		'plugin:import/typescript',
 	],
-	ignorePatterns: [ '**/config/*.js', '**/dist' ],
-	settings: {},
-	overrides: [
-		{
-			files: '**/*.test.ts',
-			env: {
-				jest: true,
-			},
-		},
-		{
-			files: [ '**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx' ],
-			rules: {
-				'jsdoc/require-jsdoc': [
-					'error',
-					{
-						require: {
-							ArrowFunctionExpression: true,
-							ClassDeclaration: true,
-							ClassExpression: true,
-							FunctionExpression: true,
-							MethodDefinition: true,
-						},
-					},
-				],
-				'import/default': [ 'off' ],
-			},
-		},
-	],
 	rules: {
 		'n/no-process-env': [ 'error' ],
 	},

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -4,7 +4,6 @@ module.exports = {
 		browser: true,
 		es6: true,
 	},
-	parser: '@typescript-eslint/parser',
 	plugins: [ '@wordpress/eslint-plugin', 'jsdoc', 'import', 'n' ],
 	extends: [
 		'plugin:@wordpress/eslint-plugin/recommended',


### PR DESCRIPTION


<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR removes the Eslint config `overrides` from `@snapwp/eslint-config` and relocates them into our own package.


## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->

We want our package to implement smart and measured rules that make sense contextually, but these leaked into the initial release. 

They may even be restored as a ruleset.

### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->

- Cherrypicked from https://github.com/rtCamp/snapwp/pull/84
- Part of https://github.com/rtCamp/headless/issues/250

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->


## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->


## Additional Info
<!-- Please include any relevant logs, error output, etc -->

This is a breaking change as those relying on those previous overrides will now need to override them themselves.


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [x] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [x] I have added a changeset for this PR using `npm run changeset`.
