### PR TITLE
dev: add compat for ScriptModuleImportTypeEnum

### DIFF
--- a/.changeset/poor-lands-study.md
+++ b/.changeset/poor-lands-study.md
@@ -1,0 +1,5 @@
+---
+"@snapwp/next": patch
+---
+
+dev: Add compatibility for `ScriptModuleDependency.importType` type change to `ScriptModuleImportTypeEnum`

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -169,7 +169,7 @@ export default function ScriptModuleExample() {
                 handle="example-main-script"
                 dependencies={[
                     {
-                        importType: 'static',
+                        importType: 'STATIC',
                         connectedScriptModule: {
                             handle: '@module',
                             src: 'http://example.com/index.min.js'

--- a/packages/next/src/components/script-module.tsx
+++ b/packages/next/src/components/script-module.tsx
@@ -49,7 +49,8 @@ export default function ScriptModule( {
 
 		const { src: depSrc, handle: depHandle } = dep.connectedScriptModule;
 
-		if ( 'static' === dep.importType ) {
+		// @todo Remove `toUpperCase()` when we drop support for snapwp-helper v0.1.0.
+		if ( 'STATIC' === dep.importType?.toUpperCase() ) {
 			return (
 				<link
 					// We use "preload" instead of "modulepreload" to resolve the race condition where the script runs before the state is loaded.


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR adds compatibility for `ScriptModuleDependency.importType` now returning an enum instead of a string.


## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->

Compatibility with https://github.com/rtCamp/snapwp-helper/pull/88

### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
 `toUpperCase()` coersion is used for backwards-compatibility. This will be stripped for our next breaking release (when we drop support for the snapwp-helper v0.1.0

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->


## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->


## Additional Info
<!-- Please include any relevant logs, error output, etc -->

I didn't bother narrowing down the types. it feels like there's gonna be a lot of type changes and no need to bump them now unnecessarily, imo.


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [x] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [x] I have added a changeset for this PR using `npm run changeset`.
