### PR TITLE
chore: Add `jsdoc/require-param-type` eslint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -67,6 +67,7 @@ module.exports = {
 
 		// Turn of JSdoc types and use TypeScript types instead.
 		'jsdoc/no-types': [ 'off' ],
+		'jsdoc/require-param-type': [ 'error' ],
 	},
 	overrides: [
 		{

--- a/packages/blocks/src/block-manager/index.tsx
+++ b/packages/blocks/src/block-manager/index.tsx
@@ -12,7 +12,8 @@ export default class BlockManager {
 
 	/**
 	 * Update block definitions to be used while rendering blocks.
-	 * @param blockDefinitions - rendering implementaion for blocks.
+	 *
+	 * @param {BlockDefinitions} blockDefinitions Rendering implementation for blocks.
 	 */
 	public static addBlockDefinitions( blockDefinitions: BlockDefinitions ) {
 		BlockManager.blockDefinitions = {
@@ -22,8 +23,10 @@ export default class BlockManager {
 	}
 
 	/**
-	 * Function to convert a flat list of blocks to a tree depending on `clientId` and `parentClientId`
-	 * @param blockList - A flat list of blocks.
+	 * Function to convert a flat list of blocks to a tree depending on `clientId` and `parentClientId`.
+	 *
+	 * @param {Array<BlockData>} blockList A flat list of blocks.
+	 *
 	 * @return A tree of blocks.
 	 */
 	public static flatListToHierarchical(
@@ -42,7 +45,8 @@ export default class BlockManager {
 	/**
 	 * Mutates the passed the node by adding a render function to a node of block tree.
 	 * if a node uses default renderer(which uses renderedHtml) prunes its children which does not need to be rendered.
-	 * @param node - A flat list of blocks.
+	 *
+	 * @param {BlockTreeNode} node A flat list of blocks.
 	 */
 	public static attachRendererToTreeNode = ( node: BlockTreeNode ): void => {
 		const customBlockDefinition =
@@ -73,7 +77,9 @@ export default class BlockManager {
 
 	/**
 	 * Pre processes a flat list of blocks for rendering.
-	 * @param blockList - A flat list of blocks.
+	 *
+	 * @param {Array<BlockData>} blockList A flat list of blocks.
+	 *
 	 * @return A tree of blocks with render functions.
 	 */
 	public static parseBlockForRendering(

--- a/packages/blocks/src/blocks/core-audio.tsx
+++ b/packages/blocks/src/blocks/core-audio.tsx
@@ -9,9 +9,9 @@ import type { CoreAudio as CoreAudioType, CoreAudioProps } from '@snapwp/types';
 /**
  * Renders the core/audio block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                      props              The props for the block component.
+ * @param {CoreAudioProps.attributes}   props.attributes   Block attributes.
+ * @param {CoreAudioProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-button.tsx
+++ b/packages/blocks/src/blocks/core-button.tsx
@@ -10,8 +10,8 @@ import type {
 /**
  * Renders the core/button block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
+ * @param {Object}                     props            The props for the block component.
+ * @param {CoreButtonProps.attributes} props.attributes Block attributes.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-buttons.tsx
+++ b/packages/blocks/src/blocks/core-buttons.tsx
@@ -8,9 +8,9 @@ import type {
 /**
  * Renders the core/buttons block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.children - The block's children.
+ * @param {Object}                      props            The props for the block component.
+ * @param {CoreButtonsProps.attributes} props.attributes Block attributes.
+ * @param {ReactNode}                   props.children   The block's children.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-code.tsx
+++ b/packages/blocks/src/blocks/core-code.tsx
@@ -6,8 +6,8 @@ import type { CoreCode as CoreCodeType, CoreCodeProps } from '@snapwp/types';
 /**
  * Renders the core/code block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
+ * @param {Object}                   props            The props for the block component.
+ * @param {CoreCodeProps.attributes} props.attributes Block attributes.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-column.tsx
+++ b/packages/blocks/src/blocks/core-column.tsx
@@ -8,9 +8,9 @@ import type {
 /**
  * Renders the core/column block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.children - The block's children.
+ * @param {Object}                     props            The props for the block component.
+ * @param {CoreColumnProps.attributes} props.attributes Block attributes.
+ * @param {ReactNode}                  props.children   The block's children.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-columns.tsx
+++ b/packages/blocks/src/blocks/core-columns.tsx
@@ -8,9 +8,9 @@ import type {
 /**
  * Renders the core/columns block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.children - The block's children.
+ * @param {Object}                      props            The props for the block component.
+ * @param {CoreColumnsProps.attributes} props.attributes Block attributes.
+ * @param {ReactNode}                   props.children   The block's children.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-cover.tsx
+++ b/packages/blocks/src/blocks/core-cover.tsx
@@ -21,7 +21,7 @@ const DEFAULT_FOCAL_POINT = { x: 0.5, y: 0.5 };
  *
  * @see https://github.com/WordPress/gutenberg/blob/887243c1cb2b3280934fbff05d4af8e46a3feddc/packages/block-library/src/cover/shared.js#L27
  *
- * @param focalPoint - The focal point coordinates object containing x and y values.
+ * @param {FocalPoint} focalPoint The focal point coordinates object containing x and y values.
  *
  * @return CSS position string or undefined if no focal point
  */
@@ -36,12 +36,14 @@ const mediaPosition = ( focalPoint?: FocalPoint | null ): string => {
 
 /**
  * Renders the core/cover block.
- * @param root0 - The component props object
- * @param root0.attributes - Block attributes including styling and media settings
- * @param root0.children - Child elements to render inside the cover
- * @param root0.renderedHtml - Pre-rendered HTML string for class extraction
- * @param root0.connectedMediaItem - The connected media item object
- * @param root0.mediaDetails - The media details object
+ *
+ * @param {Object}                            root0                    The component props object
+ * @param {CoreCoverProps.attributes}         root0.attributes         Block attributes including styling and media settings
+ * @param {ReactNode}                         root0.children           Child elements to render inside the cover
+ * @param {CoreCoverProps.renderedHtml}       root0.renderedHtml       Pre-rendered HTML string for class extraction
+ * @param {CoreCoverProps.connectedMediaItem} root0.connectedMediaItem The connected media item object
+ * @param {CoreCoverProps.mediaDetails}       root0.mediaDetails       The media details object
+ *
  * @return The rendered cover block or null if using featured image
  */
 const CoreCover: CoreCoverType = ( {

--- a/packages/blocks/src/blocks/core-cover.tsx
+++ b/packages/blocks/src/blocks/core-cover.tsx
@@ -37,12 +37,12 @@ const mediaPosition = ( focalPoint?: FocalPoint | null ): string => {
 /**
  * Renders the core/cover block.
  *
- * @param {Object}                            root0                    The component props object
- * @param {CoreCoverProps.attributes}         root0.attributes         Block attributes including styling and media settings
- * @param {ReactNode}                         root0.children           Child elements to render inside the cover
- * @param {CoreCoverProps.renderedHtml}       root0.renderedHtml       Pre-rendered HTML string for class extraction
- * @param {CoreCoverProps.connectedMediaItem} root0.connectedMediaItem The connected media item object
- * @param {CoreCoverProps.mediaDetails}       root0.mediaDetails       The media details object
+ * @param {Object}                            props                    The component props object
+ * @param {CoreCoverProps.attributes}         props.attributes         Block attributes including styling and media settings
+ * @param {ReactNode}                         props.children           Child elements to render inside the cover
+ * @param {CoreCoverProps.renderedHtml}       props.renderedHtml       Pre-rendered HTML string for class extraction
+ * @param {CoreCoverProps.connectedMediaItem} props.connectedMediaItem The connected media item object
+ * @param {CoreCoverProps.mediaDetails}       props.mediaDetails       The media details object
  *
  * @return The rendered cover block or null if using featured image
  */

--- a/packages/blocks/src/blocks/core-details.tsx
+++ b/packages/blocks/src/blocks/core-details.tsx
@@ -12,10 +12,10 @@ import type {
 /**
  * Renders the core/details block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.children - The block's children.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                        props              The props for the block component.
+ * @param {CoreDetailsProps.attributes}   props.attributes   Block attributes.
+ * @param {ReactNode}                     props.children     The block's children.
+ * @param {CoreDetailsProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-file.tsx
+++ b/packages/blocks/src/blocks/core-file.tsx
@@ -13,9 +13,9 @@ const FALLBACK_ARIA_LABEL = 'PDF embed';
 /**
  * Renders the core/file block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                     props              The props for the block component.
+ * @param {CoreFileProps.attributes}   props.attributes   Block attributes.
+ * @param {CoreFileProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-freeform.tsx
+++ b/packages/blocks/src/blocks/core-freeform.tsx
@@ -8,8 +8,8 @@ import type {
 /**
  * Renders the core/freeform block.
  *
- * @param props - The props for the block component.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                         props              The props for the block component.
+ * @param {CoreFreeformProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-gallery.tsx
+++ b/packages/blocks/src/blocks/core-gallery.tsx
@@ -12,10 +12,10 @@ import type {
 /**
  * Renders the core/gallery block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.children - The block's children.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                        props              The props for the block component.
+ * @param {CoreGalleryProps.attributes}   props.attributes   Block attributes.
+ * @param {ReactNode}                     props.children     The block's children.
+ * @param {CoreGalleryProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-group.tsx
+++ b/packages/blocks/src/blocks/core-group.tsx
@@ -13,11 +13,11 @@ import type {
 /**
  * Renders an HTML element with the specified tag name.
  *
- * @param props - The props for the block component.
- * @param props.name - The tag name of the HTML element.
- * @param props.className - Class names.
- * @param props.style - Inline styles.
- * @param props.children - The content to render inside the element.
+ * @param {Object}             props           The props for the block component.
+ * @param {TagProps.name}      props.name      The tag name of the HTML element.
+ * @param {TagProps.className} props.className Class names.
+ * @param {TagProps.style}     props.style     Inline styles.
+ * @param {ReactNode}          props.children  The content to render inside the element.
  *
  * @return The rendered HTML element or the children if no tag name is provided.
  */
@@ -32,10 +32,10 @@ const Tag = ( { name, className, style, children }: TagProps ) => {
 /**
  * Renders the core/group block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.children - The block's children.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                      props              The props for the block component.
+ * @param {CoreGroupProps.attributes}   props.attributes   Block attributes.
+ * @param {ReactNode}                   props.children     The block's children.
+ * @param {CoreGroupProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-heading.tsx
+++ b/packages/blocks/src/blocks/core-heading.tsx
@@ -9,8 +9,8 @@ import type {
 /**
  * Renders the core/heading block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
+ * @param {Object}                      props            The props for the block component.
+ * @param {CoreHeadingProps.attributes} props.attributes Block attributes.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-html.tsx
+++ b/packages/blocks/src/blocks/core-html.tsx
@@ -5,8 +5,8 @@ import type { CoreHtml as CoreHtmlType, CoreHtmlProps } from '@snapwp/types';
 /**
  * Renders the core/html block.
  *
- * @param props - The props for the block component.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                     props              The props for the block component.
+ * @param {CoreHtmlProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-image.tsx
+++ b/packages/blocks/src/blocks/core-image.tsx
@@ -18,15 +18,15 @@ import type {
 /**
  * Renders a figure element with optional link and caption.
  *
- * @param props - The properties for the figure element.
- * @param [props.children] - The children of the figure element.
- * @param [props.classNames] - The class names for the figure element.
- * @param [props.renderedHtml] - The rendered HTML.
- * @param [props.href] - The href for the link.
- * @param [props.linkClass] - The class for the link.
- * @param [props.linkTarget] - The target for the link.
- * @param [props.rel] - The rel for the link.
- * @param [props.lightbox] - The lightbox attribute.
+ * @param {Object}                   props              The properties for the figure element.
+ * @param {ReactNode}                props.children     The children of the figure element.
+ * @param {FigureProps.classNames}   props.classNames   The class names for the figure element.
+ * @param {FigureProps.renderedHtml} props.renderedHtml The rendered HTML.
+ * @param {FigureProps.href}         props.href         The href for the link.
+ * @param {FigureProps.linkClass}    props.linkClass    The class for the link.
+ * @param {FigureProps.linkTarget}   props.linkTarget   The target for the link.
+ * @param {FigureProps.rel}          props.rel          The rel for the link.
+ * @param {FigureProps.lightbox}     props.lightbox     The lightbox attribute.
  *
  * @return The rendered figure element.
  */
@@ -72,11 +72,12 @@ const Figure = ( {
  *
  * @todo Expose context and state to frontend for lightbox functionality.
  *
- * @param props - The properties for the core image block.
- * @param [props.attributes] - The attributes for the image.
- * @param [props.connectedMediaItem] - The connected media item.
- * @param [props.mediaDetails] - The media details.
- * @param [props.renderedHtml] - The rendered HTML.
+ * @param {Object}                            props                    The properties for the core image block.
+ * @param {CoreImageProps.attributes}         props.attributes         The attributes for the image.
+ * @param {CoreImageProps.connectedMediaItem} props.connectedMediaItem The connected media item.
+ * @param {CoreImageProps.mediaDetails}       props.mediaDetails       The media details.
+ * @param {CoreImageProps.renderedHtml}       props.renderedHtml       The rendered HTML.
+ *
  * @return The rendered core image block or null if no URL is provided.
  */
 const CoreImage: CoreImageType = ( {
@@ -166,9 +167,9 @@ const CoreImage: CoreImageType = ( {
 /**
  * Returns the props for the image component.
  *
- * @param [attributes] The attributes for the image.
- * @param [connectedMediaItem] The connected media item.
- * @param [mediaDetails] The media details.
+ * @param {CoreImageAttributes}         attributes         The attributes for the image.
+ * @param {CoreImageConnectedMediaItem} connectedMediaItem The connected media item.
+ * @param {CoreImageMediaDetails}       mediaDetails       The media details.
  *
  * @return The props for the image component.
  */
@@ -242,7 +243,7 @@ const getImageProps = (
 /**
  * Is Lightbox enabled for the image.
  *
- * @param lightbox - The lightbox attribute.
+ * @param {string} lightbox The lightbox attribute.
  *
  * @return Whether the lightbox is enabled.
  */
@@ -262,8 +263,8 @@ const isLightboxEnabled = ( lightbox?: string | null ) => {
 /**
  * Extracts interactivity attributes from the rendered HTML for a given element.
  *
- * @param element - The element to extract attributes for.
- * @param renderedHtml - The rendered HTML.
+ * @param {string} element      The element to extract attributes for.
+ * @param {string} renderedHtml The rendered HTML.
  *
  * @return The extracted interactivity attributes.
  */
@@ -302,8 +303,8 @@ const extractInteractivityAttributesForElement = (
 /**
  * Extracts ARIA attributes from the rendered HTML for a given element.
  *
- * @param element - The element to extract attributes for.
- * @param renderedHtml - The rendered HTML.
+ * @param {string} element      The element to extract attributes for.
+ * @param {string} renderedHtml The rendered HTML.
  *
  * @return The extracted ARIA attributes.
  */

--- a/packages/blocks/src/blocks/core-list-item.tsx
+++ b/packages/blocks/src/blocks/core-list-item.tsx
@@ -13,10 +13,10 @@ import type {
 /**
  * Renders the core/list-item block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.children - The block's children.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                         props              The props for the block component.
+ * @param {CoreListItemProps.attributes}   props.attributes   Block attributes.
+ * @param {ReactNode}                      props.children     The block's children.
+ * @param {CoreListItemProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-list.tsx
+++ b/packages/blocks/src/blocks/core-list.tsx
@@ -5,9 +5,9 @@ import type { CoreList as CoreListType, CoreListProps } from '@snapwp/types';
 /**
  * Renders the core/list block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.children - The block's children.
+ * @param {Object}                   props            The props for the block component.
+ * @param {CoreListProps.attributes} props.attributes Block attributes.
+ * @param {ReactNode}                props.children   The block's children.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-media-text.tsx
+++ b/packages/blocks/src/blocks/core-media-text.tsx
@@ -24,10 +24,11 @@ const DEFAULT_MEDIA_SIZE_SLUG = 'full';
 /**
  * Generates CSS styles for image fill based on the provided URL and focal point.
  *
- * @param url - The URL of the image.
- * @param focalPoint - The focal point of the image.
- * @param focalPoint.x - The x-coordinate of the focal point (0 to 1).
- * @param focalPoint.y - The y-coordinate of the focal point (0 to 1).
+ * @param {string}       url          The URL of the image.
+ * @param {FocalPoint}   focalPoint   The focal point of the image.
+ * @param {FocalPoint.x} focalPoint.x The x-coordinate of the focal point (0 to 1).
+ * @param {FocalPoint.y} focalPoint.y The y-coordinate of the focal point (0 to 1).
+ *
  * @return CSS styles for the image fill.
  */
 function imageFillStyles( url?: string, focalPoint?: FocalPoint ) {
@@ -45,12 +46,13 @@ function imageFillStyles( url?: string, focalPoint?: FocalPoint ) {
 /**
  * Renders a WordPress Media & Text block with support for images, videos, and linked media
  *
- * @param props - Component props
- * @param props.attributes - Block configuration attributes
- * @param props.children - Child components to render
- * @param props.renderedHtml - Raw HTML string from WordPress
- * @param props.connectedMediaItem - Connected media item
- * @param props.mediaDetails - Media details
+ * @param {Object}                                props                    Component props
+ * @param {CoreMediaTextProps.attributes}         props.attributes         Block configuration attributes
+ * @param {ReactNode}                             props.children           Child components to render
+ * @param {CoreMediaTextProps.renderedHtml}       props.renderedHtml       Raw HTML string from WordPress
+ * @param {CoreMediaTextProps.connectedMediaItem} props.connectedMediaItem Connected media item
+ * @param {CoreMediaTextProps.mediaDetails}       props.mediaDetails       Media details
+ *
  * @return Rendered component or null if no content
  */
 const CoreMediaText: CoreMediaTextType = ( {

--- a/packages/blocks/src/blocks/core-paragraph.tsx
+++ b/packages/blocks/src/blocks/core-paragraph.tsx
@@ -9,8 +9,8 @@ import type {
 /**
  * Renders the core/paragraph block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
+ * @param {Object}                        props            The props for the block component.
+ * @param {CoreParagraphProps.attributes} props.attributes Block attributes.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-pattern.tsx
+++ b/packages/blocks/src/blocks/core-pattern.tsx
@@ -7,8 +7,8 @@ import type {
 /**
  * Renders the core/pattern block.
  *
- * @param props - The props for the block component.
- * @param props.children - The block's children.
+ * @param {Object}    props          The props for the block component.
+ * @param {ReactNode} props.children The block's children.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-post-content.tsx
+++ b/packages/blocks/src/blocks/core-post-content.tsx
@@ -8,9 +8,9 @@ import type {
 /**
  * Renders the core/post-content block.
  *
- * @param props - The props for the block component.
- * @param props.children - The block's children.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                            props              The props for the block component.
+ * @param {ReactNode}                         props.children     The block's children.
+ * @param {CorePostContentProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-preformatted.tsx
+++ b/packages/blocks/src/blocks/core-preformatted.tsx
@@ -13,9 +13,9 @@ import type {
 /**
  * Renders the core/preformatted block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                             props              The props for the block component.
+ * @param {CorePreformattedProps.attributes}   props.attributes   Block attributes.
+ * @param {CorePreformattedProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-pullquote.tsx
+++ b/packages/blocks/src/blocks/core-pullquote.tsx
@@ -13,9 +13,9 @@ import type {
 /**
  * Renders the core/pullquote block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                          props              The props for the block component.
+ * @param {CorePullquoteProps.attributes}   props.attributes   Block attributes.
+ * @param {CorePullquoteProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-quote.tsx
+++ b/packages/blocks/src/blocks/core-quote.tsx
@@ -6,9 +6,9 @@ import type { CoreQuote as CoreQuoteType, CoreQuoteProps } from '@snapwp/types';
 /**
  * Renders the core/quote block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.children - The block's children.
+ * @param {Object}                    props            The props for the block component.
+ * @param {CoreQuoteProps.attributes} props.attributes Block attributes.
+ * @param {ReactNode}                 props.children   The block's children.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-separator.tsx
+++ b/packages/blocks/src/blocks/core-separator.tsx
@@ -8,8 +8,8 @@ import type {
 /**
  * Renders the core/separator block.
  *
- * @param props - The props for the block component.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                          props              The props for the block component.
+ * @param {CoreSeparatorProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-spacer.tsx
+++ b/packages/blocks/src/blocks/core-spacer.tsx
@@ -13,9 +13,9 @@ import type {
 /**
  * Renders the core/spacer block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                       props              The props for the block component.
+ * @param {CoreSpacerProps.attributes}   props.attributes   Block attributes.
+ * @param {CoreSpacerProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-template-part.tsx
+++ b/packages/blocks/src/blocks/core-template-part.tsx
@@ -8,10 +8,10 @@ import type {
 /**
  * Renders the core/template-part block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.children - The block's children.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                             props              The props for the block component.
+ * @param {CoreTemplatePartProps.attributes}   props.attributes   Block attributes.
+ * @param {ReactNode}                          props.children     The block's children.
+ * @param {CoreTemplatePartProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-verse.tsx
+++ b/packages/blocks/src/blocks/core-verse.tsx
@@ -10,9 +10,9 @@ import type { CoreVerse as CoreVerseType, CoreVerseProps } from '@snapwp/types';
 /**
  * Renders the core/verse block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                      props              The props for the block component.
+ * @param {CoreVerseProps.attributes}   props.attributes   Block attributes.
+ * @param {CoreVerseProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/core-video.tsx
+++ b/packages/blocks/src/blocks/core-video.tsx
@@ -14,8 +14,8 @@ import type {
 /**
  * Renders a list of `<track>` elements for a video.
  *
- * @param props - The props for the component.
- * @param props.tracks - An array of track objects containing `src`, `kind`, `srclang`, and `label`.
+ * @param {Object}            props        The props for the component.
+ * @param {Array<TrackProps>} props.tracks An array of track objects containing `src`, `kind`, `srclang`, and `label`.
  *
  * @return A list of `<track>` elements or `null` if no tracks are provided.
  */
@@ -41,9 +41,9 @@ const Tracks = ( { tracks }: { tracks?: TrackProps[] } ) => {
 /**
  * Renders the core/video block.
  *
- * @param props - The props for the block component.
- * @param props.attributes - Block attributes.
- * @param props.renderedHtml - The block's rendered HTML.
+ * @param {Object}                      props              The props for the block component.
+ * @param {CoreVideoProps.attributes}   props.attributes   Block attributes.
+ * @param {CoreVideoProps.renderedHtml} props.renderedHtml The block's rendered HTML.
  *
  * @return The rendered block.
  */

--- a/packages/blocks/src/blocks/default.tsx
+++ b/packages/blocks/src/blocks/default.tsx
@@ -4,8 +4,9 @@ import type { Default as DefaultType, DefaultProps } from '@snapwp/types';
 
 /**
  * Renders the default block.
- * @param props - The props for the component.
- * @param props.renderedHtml - The rendered HTML.
+ * @param {Object}                    props              The props for the component.
+ * @param {DefaultProps.renderedHtml} props.renderedHtml The rendered HTML.
+ *
  * @return The rendered default block.
  */
 const Default: DefaultType = ( { renderedHtml }: DefaultProps ) => {

--- a/packages/blocks/src/editor-blocks-renderer/index.tsx
+++ b/packages/blocks/src/editor-blocks-renderer/index.tsx
@@ -11,9 +11,11 @@ type EditorBlocksRendererProps = {
 
 /**
  * A react component to render editor blocks.
- * @param props - Props.
- * @param props.editorBlocks - A list of blocks to be rendered.
- * @param props.blockDefinitions - Blocks rendering functions.
+ *
+ * @param {Object}                                 props                  Props.
+ * @param {EditorBlocksRendererProps.editorBlocks} props.editorBlocks     A list of blocks to be rendered.
+ * @param {EditorBlocksRendererProps}              props.blockDefinitions Blocks rendering functions.
+ *
  * @return The rendered template
  */
 export default function EditorBlocksRenderer( {

--- a/packages/blocks/src/editor-blocks-renderer/index.tsx
+++ b/packages/blocks/src/editor-blocks-renderer/index.tsx
@@ -11,9 +11,9 @@ type EditorBlocksRendererProps = {
 /**
  * A react component to render editor blocks.
  *
- * @param {Object}                                 props                  Props.
- * @param {EditorBlocksRendererProps.editorBlocks} props.editorBlocks     A list of blocks to be rendered.
- * @param {EditorBlocksRendererProps}              props.blockDefinitions Blocks rendering functions.
+ * @param {Object}                                     props                  Props.
+ * @param {EditorBlocksRendererProps.editorBlocks}     props.editorBlocks     A list of blocks to be rendered.
+ * @param {EditorBlocksRendererProps.blockDefinitions} props.blockDefinitions Blocks rendering functions.
  *
  * @return The rendered template
  */

--- a/packages/blocks/src/utils/flat-list-to-hierarchical.ts
+++ b/packages/blocks/src/utils/flat-list-to-hierarchical.ts
@@ -9,11 +9,12 @@ type Data = Record< string | number, unknown >;
 /**
  * Converts a flat list to hierarchical.
  *
- * @param data The data items as an array.
- * @param options The data item property keys.
- * @param options.idKey The key for the unique identifier.
- * @param options.parentKey The key for the parent identifier.
- * @param options.childrenKey The key for the children.
+ * @param {Array<Data>}         data                The data items as an array.
+ * @param {Options}             options             The data item property keys.
+ * @param {Options.idKey}       options.idKey       The key for the unique identifier.
+ * @param {Options.parentKey}   options.parentKey   The key for the parent identifier.
+ * @param {Options.childrenKey} options.childrenKey The key for the children.
+ *
  * @return Data Array
  */
 export default function flatListToHierarchical(

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -41,7 +41,8 @@ const prompt = ( query ) => {
  * Opens a file in the default or specified editor and waits for the editor process to exit.
  * This function resolves with a success object indicating the result of the operation.
  *
- * @param filePath - The path to the file to be opened in the editor.
+ * @param {string} filePath - The path to the file to be opened in the editor.
+ *
  * @return - A promise that resolves to an object containing:
  *                              - success: {boolean} Indicates if the operation was successful.
  *                              - message: {string} Provides additional information or error details.

--- a/packages/core/src/config/snapwp-config-manager.ts
+++ b/packages/core/src/config/snapwp-config-manager.ts
@@ -128,7 +128,8 @@ class SnapWPConfigManager {
 			/**
 			 * Validate the URL.
 			 *
-			 * @param value The value to validate.
+			 * @param {string} value The value to validate.
+			 *
 			 * @throws {Error} If the value is invalid.
 			 */
 			validate: ( value ) => {
@@ -143,7 +144,8 @@ class SnapWPConfigManager {
 			/**
 			 * Validate the URL.
 			 *
-			 * @param value The value to validate.
+			 * @param {string} value The value to validate.
+			 *
 			 * @throws {Error} If the value is invalid.
 			 */
 			validate: ( value ) => {
@@ -162,7 +164,7 @@ class SnapWPConfigManager {
 			/**
 			 * Validate the uploads directory.
 			 *
-			 * @param value The value to validate.
+			 * @param {string} value The value to validate.
 			 *
 			 * @throws {Error} If the value is invalid.
 			 */
@@ -180,7 +182,7 @@ class SnapWPConfigManager {
 			/**
 			 * Validate the REST URL prefix.
 			 *
-			 * @param value The value to validate.
+			 * @param {string} value The value to validate.
 			 *
 			 * @throws {Error} If the value is invalid.
 			 */
@@ -198,7 +200,7 @@ class SnapWPConfigManager {
 			/**
 			 * Validate the CORS proxy prefix.
 			 *
-			 * @param value The value to validate.
+			 * @param {string} value The value to validate.
 			 *
 			 * @throws {Error} If the value is invalid.
 			 */
@@ -219,7 +221,8 @@ class SnapWPConfigManager {
 	/**
 	 * Normalizes the configuration.
 	 *
-	 * @param cfg The configuration to normalize.
+	 * @param {Partial<Type>} cfg The configuration to normalize.
+	 *
 	 * @return The normalized configuration.
 	 */
 	static normalizeConfig = < T >( cfg: Partial< T > ) => {
@@ -271,7 +274,7 @@ class SnapWPConfigManager {
 	 * 2. Config file.
 	 * 3. Default values.
 	 *
-	 * @param cfg The configuration object.
+	 * @param {Partial<SnapWPConfig>} cfg The configuration object.
 	 */
 	static setConfig( cfg?: Partial< SnapWPConfig > ): void {
 		if ( SnapWPConfigManager.configsSet ) {
@@ -301,10 +304,11 @@ class SnapWPConfigManager {
 	/**
 	 * Validate and resolve the configuration.
 	 *
-	 * @param config The configuration to validate.
-	 * @param schema The schema to validate the configuration against.
+	 * @param {Partial<Type>}      config The configuration to validate.
+	 * @param {ConfigSchema<Type>} schema The schema to validate the configuration against.
 	 *
 	 * @return The resolved configuration.
+	 *
 	 * @throws {Error} If the configuration is invalid.
 	 */
 	static validateConfig = < T >(
@@ -318,7 +322,7 @@ class SnapWPConfigManager {
 		/**
 		 * Validate a property.
 		 *
-		 * @param key The property key.
+		 * @param {keyof Type} key The property key.
 		 *
 		 * @throws {Error} If the property is invalid.
 		 */

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -5,7 +5,7 @@ class TemplateParseError extends Error {
 	/**
 	 * Constructor.
 	 *
-	 * @param message The error message.
+	 * @param {string} message The error message.
 	 */
 	constructor( message: string ) {
 		super( message );
@@ -20,7 +20,7 @@ class GlobalStylesParseError extends Error {
 	/**
 	 * Constructor.
 	 *
-	 * @param message - The error message.
+	 * @param {string} message The error message.
 	 */
 	constructor( message: string ) {
 		super( message );

--- a/packages/core/src/logger/index.ts
+++ b/packages/core/src/logger/index.ts
@@ -3,21 +3,15 @@
  *
  * @internal
  */
-export const LOGTYPE = {
-	DEBUG: 0,
-	INFO: 1,
-	WARN: 2,
-	ERROR: 3,
-	LOG: 4,
-};
+export type LOGTYPE = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'LOG';
 
 /**
  * Logs a message to the console.
  *
- * @param {number} type The type of log message.
+ * @param {LOGTYPE} type The type of log message.
  * @param {Array}  args The arguments to log.
  */
-const log = ( type: number, ...args: unknown[] ): void => {
+const log = ( type: LOGTYPE, ...args: unknown[] ): void => {
 	if (
 		// eslint-disable-next-line n/no-process-env -- Allow the use of process.env to check the current environment.
 		'production' === process.env.NODE_ENV ||
@@ -30,19 +24,19 @@ const log = ( type: number, ...args: unknown[] ): void => {
 	const prefix = 'SnapWP:';
 	/* eslint-disable no-console -- Allow the use of console for loggers. */
 	switch ( type ) {
-		case LOGTYPE.DEBUG:
+		case 'DEBUG':
 			console.debug( prefix, ...args );
 			break;
-		case LOGTYPE.INFO:
+		case 'INFO':
 			console.info( prefix, ...args );
 			break;
-		case LOGTYPE.WARN:
+		case 'WARN':
 			console.warn( prefix, ...args );
 			break;
-		case LOGTYPE.ERROR:
+		case 'ERROR':
 			console.error( prefix, ...args );
 			break;
-		case LOGTYPE.LOG:
+		case 'LOG':
 			console.log( prefix, ...args );
 			break;
 	}
@@ -62,8 +56,7 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static debug = ( ...args: unknown[] ): void =>
-		log( LOGTYPE.DEBUG, ...args );
+	static debug = ( ...args: unknown[] ): void => log( 'DEBUG', ...args );
 
 	/**
 	 * Logs an info message in the console in dev mode
@@ -74,7 +67,7 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static info = ( ...args: unknown[] ): void => log( LOGTYPE.INFO, ...args );
+	static info = ( ...args: unknown[] ): void => log( 'INFO', ...args );
 
 	/**
 	 * Logs a warning in the console in dev mode
@@ -85,7 +78,7 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static warn = ( ...args: unknown[] ): void => log( LOGTYPE.WARN, ...args );
+	static warn = ( ...args: unknown[] ): void => log( 'WARN', ...args );
 
 	/**
 	 * Logs an error in the console in dev mode
@@ -96,8 +89,7 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static error = ( ...args: unknown[] ): void =>
-		log( LOGTYPE.ERROR, ...args );
+	static error = ( ...args: unknown[] ): void => log( 'ERROR', ...args );
 
 	/**
 	 * Logs a message in the console in dev mode
@@ -108,7 +100,7 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static log = ( ...args: unknown[] ): void => log( LOGTYPE.LOG, ...args );
+	static log = ( ...args: unknown[] ): void => log( 'LOG', ...args );
 }
 
 export { Logger };

--- a/packages/core/src/logger/index.ts
+++ b/packages/core/src/logger/index.ts
@@ -3,21 +3,21 @@
  *
  * @internal
  */
-export enum LOGTYPE {
-	DEBUG,
-	INFO,
-	WARN,
-	ERROR,
-	LOG,
-}
+export const LOGTYPE = {
+	DEBUG: 0,
+	INFO: 1,
+	WARN: 2,
+	ERROR: 3,
+	LOG: 4,
+};
 
 /**
  * Logs a message to the console.
  *
- * @param {LOGTYPE} type The type of log message.
- * @param {Array}   args The arguments to log.
+ * @param {number} type The type of log message.
+ * @param {Array}  args The arguments to log.
  */
-const log = ( type: LOGTYPE, ...args: unknown[] ): void => {
+const log = ( type: number, ...args: unknown[] ): void => {
 	if (
 		// eslint-disable-next-line n/no-process-env -- Allow the use of process.env to check the current environment.
 		'production' === process.env.NODE_ENV ||

--- a/packages/core/src/logger/index.ts
+++ b/packages/core/src/logger/index.ts
@@ -14,8 +14,8 @@ export enum LOGTYPE {
 /**
  * Logs a message to the console.
  *
- * @param type - The type of log message.
- * @param args - The arguments to log.
+ * @param {LOGTYPE} type The type of log message.
+ * @param {Array}   args The arguments to log.
  */
 const log = ( type: LOGTYPE, ...args: any[] ): void => {
 	if (
@@ -56,7 +56,7 @@ class Logger {
 	/**
 	 * Logs a debug message in the console in dev mode
 	 *
-	 * @param args - The arguments to log.
+	 * @param {Array} args The arguments to log.
 	 *
 	 * @example Logger.debug("This is a debug message.")
 	 *
@@ -67,7 +67,7 @@ class Logger {
 	/**
 	 * Logs an info message in the console in dev mode
 	 *
-	 * @param args - The arguments to log.
+	 * @param {Array} args The arguments to log.
 	 *
 	 * @example Logger.info("This is an info message.")
 	 *
@@ -78,7 +78,7 @@ class Logger {
 	/**
 	 * Logs a warning in the console in dev mode
 	 *
-	 * @param args - The arguments to log.
+	 * @param {Array} args The arguments to log.
 	 *
 	 * @example Logger.warn("You should do/change something.")
 	 *
@@ -89,7 +89,7 @@ class Logger {
 	/**
 	 * Logs an error in the console in dev mode
 	 *
-	 * @param args - The arguments to log.
+	 * @param {Array} args The arguments to log.
 	 *
 	 * @example Logger.error("An error occurred.")
 	 *
@@ -100,7 +100,7 @@ class Logger {
 	/**
 	 * Logs a message in the console in dev mode
 	 *
-	 * @param args - The arguments to log.
+	 * @param {Array} args The arguments to log.
 	 *
 	 * @example Logger.log("This is a message.")
 	 *

--- a/packages/core/src/utils/cn.ts
+++ b/packages/core/src/utils/cn.ts
@@ -3,7 +3,8 @@ import { type ClassValue, clsx } from 'clsx';
 /**
  * Combines class names.
  *
- * @param  inputs - Class names or objects to combine.
+ * @param {Array<ClassValue>} inputs Class names or objects to combine.
+ *
  * @return Joined class names.
  *
  * @internal

--- a/packages/core/src/utils/find-element-and-get-class-names.ts
+++ b/packages/core/src/utils/find-element-and-get-class-names.ts
@@ -3,8 +3,8 @@ import { getClassNamesFromString, cn } from '@/utils';
 /**
  * Extracts the class names from the specified HTML element within the rendered HTML string.
  *
- * @param {string|null} renderedHtml    The rendered HTML string.
- * @param {string}      elementSelector The element selector (class, id, or tag name) If selector is not provided then it will select the first element and will return it's classNames.
+ * @param {string|null|undefined} renderedHtml    The rendered HTML string.
+ * @param {string|undefined}      elementSelector The element selector (class, id, or tag name) If selector is not provided then it will select the first element and will return it's classNames.
  *
  * @return The extracted class names from the first occurrence of the specified element or an empty string if the element is not found.
  */

--- a/packages/core/src/utils/find-element-and-get-class-names.ts
+++ b/packages/core/src/utils/find-element-and-get-class-names.ts
@@ -3,8 +3,8 @@ import { getClassNamesFromString, cn } from '@/utils';
 /**
  * Extracts the class names from the specified HTML element within the rendered HTML string.
  *
- * @param renderedHtml - The rendered HTML string.
- * @param elementSelector - The element selector (class, id, or tag name) If selector is not provided then it will select the first element and will return it's classNames.
+ * @param {string|null} renderedHtml    The rendered HTML string.
+ * @param {string}      elementSelector The element selector (class, id, or tag name) If selector is not provided then it will select the first element and will return it's classNames.
  *
  * @return The extracted class names from the first occurrence of the specified element or an empty string if the element is not found.
  */

--- a/packages/core/src/utils/generate-graphql-url.ts
+++ b/packages/core/src/utils/generate-graphql-url.ts
@@ -3,8 +3,8 @@ import { Logger } from '@/logger';
 /**
  * Generates the complete GraphQL URL based on env vars.
  *
- * @param homeUrl The home URL.
- * @param graphqlEndpoint The GraphQL endpoint.
+ * @param {string} homeUrl         The home URL.
+ * @param {string} graphqlEndpoint The GraphQL endpoint.
  *
  * @return The complete GraphQL URL.
  */

--- a/packages/core/src/utils/get-class-names-from-string.ts
+++ b/packages/core/src/utils/get-class-names-from-string.ts
@@ -1,7 +1,8 @@
 /**
  * Extracts class names from the `class` attribute in an HTML string.
  *
- * @param html - The HTML string to parse.
+ * @param {string} html The HTML string to parse.
+ *
  * @return An array of class names.
  */
 export default function getClassNamesFromString( html: string ): string[] {

--- a/packages/core/src/utils/get-color-class-name.ts
+++ b/packages/core/src/utils/get-color-class-name.ts
@@ -1,8 +1,9 @@
 /**
  * Generates a CSS class name for a given color context and color slug.
  *
- * @param colorContextName - The context name for the color (e.g., 'background', 'text').
- * @param colorSlug - The slug for the color (e.g., 'primary', 'secondary').
+ * @param {string} colorContextName The context name for the color (e.g., 'background', 'text').
+ * @param {string} colorSlug        The slug for the color (e.g., 'primary', 'secondary').
+ *
  * @return The generated CSS class name or undefined if parameters are missing.
  */
 export default function getColorClassName(

--- a/packages/core/src/utils/get-image-size-from-attributes.ts
+++ b/packages/core/src/utils/get-image-size-from-attributes.ts
@@ -29,7 +29,8 @@ const imageSizeToHeight: {
 /**
  * Retrieves the width and height based on image attributes.
  *
- * @param attributes - Image size attributes including sizeSlug, width, and height.
+ * @param {ImageSizeAttributes} attributes Image size attributes including sizeSlug, width, and height.
+ *
  * @return An object containing the width and height in pixels.
  *
  * @internal

--- a/packages/core/src/utils/get-px-for-size-attribute.ts
+++ b/packages/core/src/utils/get-px-for-size-attribute.ts
@@ -1,7 +1,8 @@
 /**
  * Converts a size attribute to pixels.
  *
- * @param sizeAttribute - The size attribute string (e.g., "10em", "50%").
+ * @param {string} sizeAttribute The size attribute string (e.g., "10em", "50%").
+ *
  * @return The size in pixels.
  *
  * @internal

--- a/packages/core/src/utils/get-spacing-preset-css-var.ts
+++ b/packages/core/src/utils/get-spacing-preset-css-var.ts
@@ -3,7 +3,7 @@
  *
  * @see https://github.com/WordPress/gutenberg/blob/da50610ac45e2cd18b59424d260bb3d693535061/packages/block-editor/src/components/spacing-sizes-control/utils.js#L128
  *
- * @param value Value to convert.
+ * @param {string|null|undefined} value Value to convert.
  *
  * @return  CSS var string for given spacing preset value.
  */

--- a/packages/core/src/utils/get-style-object-from-string.ts
+++ b/packages/core/src/utils/get-style-object-from-string.ts
@@ -4,8 +4,9 @@ import { Logger } from '@/logger';
 /**
  * Formats a string to camel case.
  *
- * @param str - The input string.
- * @return The camelcased string.
+ * @param {string} str The input string.
+ *
+ * @return The camelcase string.
  *
  * @internal
  */
@@ -30,7 +31,8 @@ function formatStringToCamelCase( str: string ): string {
 /**
  * Converts a CSS string to an object.
  *
- * @param str - The CSS string.
+ * @param {string} str The CSS string.
+ *
  * @return The style object.
  */
 function cssToReactStyle( str: string ): CSSProperties {
@@ -54,7 +56,8 @@ function cssToReactStyle( str: string ): CSSProperties {
 /**
  * Converts a CSS string or object to a React style object.
  *
- * @param css - The CSS string.
+ * @param {Object|string} css The CSS string.
+ *
  * @return The style object.
  */
 export default function getStyleObjectFromString(

--- a/packages/core/src/utils/get-styles-from-attributes.ts
+++ b/packages/core/src/utils/get-styles-from-attributes.ts
@@ -8,7 +8,8 @@ interface AttributesWithStyle {
 /**
  * Extracts and compiles styles from attributes.
  *
- * @param attributes - Object containing a style string.
+ * @param {AttributesWithStyle} attributes Object containing a style string.
+ *
  * @return Compiled styles as an object or an empty object if no styles exist.
  */
 export default function getStylesFromAttributes(

--- a/packages/core/src/utils/is-valid-url.ts
+++ b/packages/core/src/utils/is-valid-url.ts
@@ -1,5 +1,8 @@
 /**
- * @param str A string to be validated as a Url.
+ * Check if the URL is valid.
+ *
+ * @param {string} str A string to be validated as a URL.
+ *
  * @return flag signifying validity.
  *
  * @internal

--- a/packages/core/src/utils/parse-external-remote-patterns.ts
+++ b/packages/core/src/utils/parse-external-remote-patterns.ts
@@ -1,6 +1,8 @@
 /**
  * Parses given string into remote patterns.
- * @param str URLs for external image sources in a comma seperated fashion.
+ *
+ * @param {string} str URLs for external image sources in a comma seperated fashion.
+ *
  * @return an array of remote patterns to be used in next.config.js
  *
  * @internal

--- a/packages/core/src/utils/replace-host-url.ts
+++ b/packages/core/src/utils/replace-host-url.ts
@@ -1,9 +1,10 @@
 /**
  * Converts the WordPress server URL to an internal one.
  *
- * @param url - WP url.
- * @param hostUrl - Host url to be replaced.
- * @param newHostUrl - Host url to be replaced with.
+ * @param {string} url        WP url.
+ * @param {string} hostUrl    Host url to be replaced.
+ * @param {string} newHostUrl Host url to be replaced with.
+ *
  * @return The internal url.
  *
  * @internal

--- a/packages/core/src/utils/url-slash-modify.ts
+++ b/packages/core/src/utils/url-slash-modify.ts
@@ -1,7 +1,7 @@
 /**
  * Remove trailing slash from the URL.
  *
- * @param url The URL to modify.
+ * @param {string} url The URL to modify.
  *
  * @return The modified URL.
  *
@@ -14,7 +14,7 @@ export function removeTrailingSlash( url: string ): string {
 /**
  * Add trailing slash to the URL.
  *
- * @param url The URL to modify.
+ * @param {string} url The URL to modify.
  *
  * @return The modified URL.
  *
@@ -27,7 +27,7 @@ export function addTrailingSlash( url: string ): string {
 /**
  * Remove leading slash from the URL.
  *
- * @param url The URL to modify.
+ * @param {string} url The URL to modify.
  *
  * @return The modified URL.
  *
@@ -40,7 +40,7 @@ export function removeLeadingSlash( url: string ): string {
 /**
  * Add leading slash to the URL.
  *
- * @param url The URL to modify.
+ * @param {string} url The URL to modify.
  *
  * @return The modified URL.
  *

--- a/packages/e2e-tests/src/utils/wait-for-server.ts
+++ b/packages/e2e-tests/src/utils/wait-for-server.ts
@@ -1,9 +1,10 @@
 /**
  * Waits for a server to respond within a given number of attempts.
  *
- * @param url - The server URL to check.
- * @param timeout - Max wait time per attempt in ms.
- * @param retries - Number of retry attempts (default: 5).
+ * @param {string} url     The server URL to check.
+ * @param {number} timeout Max wait time per attempt in ms.
+ * @param {number} retries Number of retry attempts (default: 5).
+ *
  * @throws If the server doesn't respond after all retries.
  */
 export default async function waitForServer(

--- a/packages/next/src/components/default-error.tsx
+++ b/packages/next/src/components/default-error.tsx
@@ -8,9 +8,9 @@ import React from 'react';
  * This component is exported directly from `package.json` to prevent conflicts with other components when importing it from the Next.js package.
  * This resolves the issue of `You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory`
  *
- * @param root0 - The props.
- * @param root0.error - The error.
- * @param root0.reset - The reset function.
+ * @param {Object}   root0       The props.
+ * @param {Error}    root0.error The error.
+ * @param {Function} root0.reset The reset function.
  *
  * @return The default error component.
  */

--- a/packages/next/src/components/default-error.tsx
+++ b/packages/next/src/components/default-error.tsx
@@ -6,9 +6,9 @@
  * This component is exported directly from `package.json` to prevent conflicts with other components when importing it from the Next.js package.
  * This resolves the issue of `You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory`
  *
- * @param {Object}   root0       The props.
- * @param {Error}    root0.error The error.
- * @param {Function} root0.reset The reset function.
+ * @param {Object}   props       The props.
+ * @param {Error}    props.error The error.
+ * @param {Function} props.reset The reset function.
  *
  * @return The default error component.
  */

--- a/packages/next/src/components/font.tsx
+++ b/packages/next/src/components/font.tsx
@@ -3,8 +3,9 @@ import React from 'react';
 /**
  * A wrapper for loading fonts dynamically using next/font.
  *
- * @param props - Props for the Font component.
- * @param props.renderedFontFaces - Font face data as a string.
+ * @param {Object} props                   Props for the Font component.
+ * @param {string} props.renderedFontFaces Font face data as a string.
+ *
  * @return A style tag with the rendered font faces.
  *
  * @todo Implement next/font once a solution for handling literal types is determined.

--- a/packages/next/src/components/image.tsx
+++ b/packages/next/src/components/image.tsx
@@ -36,15 +36,15 @@ interface ImageInterface {
  * Note: The next/image component applies style { color: transparent; } to an image when it loads successfully, ensuring the alt text is hidden. If the image fails to load, this style isn’t applied, making the alt text visible instead.
  * @see https://github.com/vercel/next.js/blob/v15.1.3/packages/next/src/shared/lib/get-img-props.ts#L625
  *
- * @param props - Props for the component.
- * @param props.alt - Alt text for the image.
- * @param props.image - Media item containing image details.
- * @param props.width - Width of the image.
- * @param props.height - Height of the image.
- * @param props.className - CSS class names.
- * @param props.priority - If true, loads the image with higher priority.
- * @param props.fill - If true, fills the container.
- * @param props.src - Source URL for the image.
+ * @param {Object}                   props           Props for the component.
+ * @param {ImageInterface.alt}       props.alt       Alt text for the image.
+ * @param {ImageInterface.image}     props.image     Media item containing image details.
+ * @param {ImageInterface.width}     props.width     Width of the image.
+ * @param {ImageInterface.height}    props.height    Height of the image.
+ * @param {ImageInterface.className} props.className CSS class names.
+ * @param {ImageInterface.priority}  props.priority  If true, loads the image with higher priority.
+ * @param {ImageInterface.fill}      props.fill      If true, fills the container.
+ * @param {ImageInterface.src}       props.src       Source URL for the image.
  *
  * @return The rendered image.
  */

--- a/packages/next/src/components/link.tsx
+++ b/packages/next/src/components/link.tsx
@@ -16,11 +16,11 @@ interface LinkInterface {
 /**
  * Link component to handle internal and external links.
  *
- * @param props - Props for the component.
- * @param props.href - Link's href attribute.
- * @param props.style - CSS style object.
- * @param props.className - CSS class name.
- * @param props.children - Block's Children.
+ * @param {Object}                  props           Props for the component.
+ * @param {LinkInterface.href}      props.href      Link's href attribute.
+ * @param {LinkInterface.style}     props.style     CSS style object.
+ * @param {LinkInterface.className} props.className CSS class name.
+ * @param {ReactNode}               props.children  Block's Children.
  *
  * @return The rendered link.
  */

--- a/packages/next/src/components/script-module.tsx
+++ b/packages/next/src/components/script-module.tsx
@@ -27,11 +27,12 @@ interface ScriptModuleInterface {
  * A reusable wrapper for Next.js Script component to handle script modules and their dependencies.
  * Uses Next.js script loading strategies to optimize loading behavior.
  *
- * @param props - Props for the Script Module component
- * @param props.handle - The unique identifier for the script module
- * @param props.src - The source URL for the script module
- * @param props.extraData - Additional data required by the script module
- * @param props.dependencies - Dependencies required by the script module
+ * @param {Object}                             props              Props for the Script Module component.
+ * @param {ScriptModuleInterface.handle}       props.handle       The unique identifier for the script module.
+ * @param {ScriptModuleInterface.src}          props.src          The source URL for the script module.
+ * @param {ScriptModuleInterface.extraData}    props.extraData    Additional data required by the script module.
+ * @param {ScriptModuleInterface.dependencies} props.dependencies Dependencies required by the script module.
+ *
  * @return The rendered script module elements
  */
 export default function ScriptModule( {

--- a/packages/next/src/components/script.tsx
+++ b/packages/next/src/components/script.tsx
@@ -14,14 +14,15 @@ interface ScriptInterface {
 /**
  * A reusable wrapper for Next.js Script component.
  *
- * @param props - Props for the Script component.
- * @param props.after - Scripts to be executed after the main script.
- * @param props.before - Scripts to be executed before the main script.
- * @param props.extraData - Additional data to be included in the script.
- * @param props.handle - The handle for the script.
- * @param props.loadingStrategy - The loading strategy for the script (async or defer).
- * @param props.location - The location where the script should be loaded.
- * @param props.src - The source URL for the script.
+ * @param {Object}                          props                 Props for the Script component.
+ * @param {ScriptInterface.after}           props.after           Scripts to be executed after the main script.
+ * @param {ScriptInterface.before}          props.before          Scripts to be executed before the main script.
+ * @param {ScriptInterface.extraData}       props.extraData       Additional data to be included in the script.
+ * @param {ScriptInterface.handle}          props.handle          The handle for the script.
+ * @param {ScriptInterface.loadingStrategy} props.loadingStrategy The loading strategy for the script (async or defer).
+ * @param {ScriptInterface.location}        props.location        The location where the script should be loaded.
+ * @param {ScriptInterface.src}             props.src             The source URL for the script.
+ *
  * @return The rendered script element.
  */
 export default function Script( {

--- a/packages/next/src/config/with-snap-wp.ts
+++ b/packages/next/src/config/with-snap-wp.ts
@@ -12,15 +12,18 @@ import {
  * Modifies the webpack configuration to include SnapWP configuration.
  * TODO: Explore a better approach to support Turbopack.
  *
- * @param snapWPConfigPath The path to the SnapWP configuration file.
+ * @param {string} snapWPConfigPath The path to the SnapWP configuration file.
+ *
  * @return A function that modifies the webpack configuration.
  */
 const modifyWebpackConfig = ( snapWPConfigPath: string ) => {
 	/**
 	 * Modifies the webpack configuration. This function is called by Next.js.
 	 *
-	 * @param config The webpack configuration. Using `any` type as the parameter type is `any` in Next.js.
+	 * @param {any} config The webpack configuration. Using `any` type as the parameter type is `any` in Next.js.
+	 *
 	 * @see node_modules/next/dist/server/config-shared.js:169
+	 *
 	 * @return The modified webpack configuration.
 	 */
 	return ( config: any ) => {
@@ -35,7 +38,8 @@ const modifyWebpackConfig = ( snapWPConfigPath: string ) => {
 						/**
 						 * Tests whether the module should be modified.
 						 *
-						 * @param normalModule The normal module being processed.
+						 * @param {NormalModule} normalModule The normal module being processed.
+						 *
 						 * @return `true` if the module should be modified, otherwise `false`.
 						 */
 						test: ( normalModule ) => {
@@ -73,7 +77,8 @@ const modifyWebpackConfig = ( snapWPConfigPath: string ) => {
 /**
  * Extends the Next.js configuration with SnapWP configuration.
  *
- * @param nextConfig The Next.js configuration object.
+ * @param {NextConfig} nextConfig The Next.js configuration object.
+ *
  * @return The extended configuration object.
  */
 const withSnapWP = async ( nextConfig?: NextConfig ): Promise< NextConfig > => {

--- a/packages/next/src/middleware/cors.ts
+++ b/packages/next/src/middleware/cors.ts
@@ -14,7 +14,8 @@ import type { MiddlewareFactory } from './utils';
  * eg: http://localhost:3000/proxy/assets/api.js will get resouce at https://examplewp/assets/api.js
  * assuming env vars NEXT_PUBLIC_URL had its value set to http://localhost:3000 and NEXT_PUBLIC_WORDPRESS_URL to https://examplewp.com
  *
- * @param  next - Next middleware
+ * @param {NextMiddleware} next Next middleware.
+ *
  * @return The response object with modified headers
  */
 export const corsProxyMiddleware: MiddlewareFactory = (

--- a/packages/next/src/middleware/current-path.ts
+++ b/packages/next/src/middleware/current-path.ts
@@ -7,7 +7,8 @@ import type { MiddlewareFactory } from './utils';
  * This middleware adds a custom header 'x-current-path' to the response,
  * which contains the current pathname of the request.
  *
- * @param  next - Next middleware
+ * @param {NextMiddleware} next Next middleware.
+ *
  * @return The response object with modified headers
  */
 export const currentPath: MiddlewareFactory = ( next: NextMiddleware ) => {

--- a/packages/next/src/middleware/proxies.ts
+++ b/packages/next/src/middleware/proxies.ts
@@ -13,7 +13,8 @@ import type { MiddlewareFactory } from './utils';
  *
  * This middleware adds custom proxies.
  *
- * @param  next - Next middleware
+ * @param {NextMiddleware} next Next middleware.
+ *
  * @return Custom redirection or NextMiddleware.
  */
 export const proxies: MiddlewareFactory = ( next: NextMiddleware ) => {

--- a/packages/next/src/middleware/utils.ts
+++ b/packages/next/src/middleware/utils.ts
@@ -12,10 +12,10 @@ export type MiddlewareFactory = (
  * Stacks middlewares.
  * Ref: https://reacthustle.com/blog/how-to-chain-multiple-middleware-functions-in-nextjs
  *
- * @param functions               Array containing Middleware.
- * @param index                   Index of current middleware.
- * @param stackDefaultMiddlewares Weather to add load default middlewares with custom ones.
- *                                Pass false to skip loading default middlewares.
+ * @param {Array<MiddlewareFactory>} functions               Array containing Middleware.
+ * @param {number}                   index                   Index of current middleware.
+ * @param {boolean}                  stackDefaultMiddlewares Weather to add load default middlewares with custom ones.
+ *                                                           Pass false to skip loading default middlewares.
  *
  * @return NextMiddleware
  */
@@ -43,7 +43,7 @@ export function appMiddlewares(
 /**
  * Stacks default middlewares with the custom middlewares passed by user.
  *
- * @param middlewares Array containing user defined Middlewares.
+ * @param {Array<MiddlewareFactory>} middlewares Array containing user defined Middlewares.
  *
  * @return Array combining default middlewares and custom middlewares.
  */

--- a/packages/next/src/react-parser/index.tsx
+++ b/packages/next/src/react-parser/index.tsx
@@ -6,8 +6,9 @@ import type { HTMLReactParserOptions } from 'html-react-parser';
 /**
  * Parses HTML string into React components.
  *
- * @param props - The props for the parser.
- * @param props.html - The HTML string to parse and render.
+ * @param {Object} props      The props for the parser.
+ * @param {string} props.html The HTML string to parse and render.
+ *
  * @return The rendered React components.
  */
 export default function Parse( { html }: { html: string } ) {

--- a/packages/next/src/react-parser/options.tsx
+++ b/packages/next/src/react-parser/options.tsx
@@ -16,7 +16,8 @@ export const defaultOptions: HTMLReactParserOptions = {
 	/**
 	 * Replaces anchor tags with Next.js Link components.
 	 *
-	 * @param domNode - The DOM node being processed.
+	 * @param {DOMNode} domNode The DOM node being processed.
+	 *
 	 * @return A React element if the node is an anchor tag, otherwise undefined.
 	 */
 	replace: ( domNode ) => {

--- a/packages/next/src/root-layout/global-head.tsx
+++ b/packages/next/src/root-layout/global-head.tsx
@@ -6,10 +6,11 @@ import { type GlobalHeadProps } from '@snapwp/core';
  * Renders the head section with custom styles, block styles, global stylesheet,
  * rendered font faces for the global context.
  *
- * @param props - The props for the component.
- * @param props.customCss - Custom CSS to be included.
- * @param props.globalStylesheet - Global stylesheet for the page.
- * @param props.renderedFontFaces - Font faces rendered locally.
+ * @param {Object}      props                   The props for the component.
+ * @param {string|null} props.customCss         Custom CSS to be included.
+ * @param {string|null} props.globalStylesheet  Global stylesheet for the page.
+ * @param {string|null} props.renderedFontFaces Font faces rendered locally.
+ *
  * @return A head element containing the provided styles and links.
  */
 export function GlobalHead( {

--- a/packages/next/src/root-layout/index.tsx
+++ b/packages/next/src/root-layout/index.tsx
@@ -8,9 +8,10 @@ export type RootLayoutProps = {
 
 /**
  * The RootLayout to be used in a NextJS app.
- * @param props - The props for the renderer.
- * @param props.getGlobalStyles - A async callback to get global styles.
- * @param props.children - Child components.
+ *
+ * @param {Object}                          props                 The props for the renderer.
+ * @param {RootLayoutProps.getGlobalStyles} props.getGlobalStyles A async callback to get global styles.
+ * @param {ReactNode}                       props.children        Child components.
  *
  * @return The rendered template
  */

--- a/packages/next/src/template-renderer/index.tsx
+++ b/packages/next/src/template-renderer/index.tsx
@@ -15,9 +15,10 @@ export type TemplateRendererProps = {
  * Renders a full HTML document including the head, body, and scripts.
  * Combines custom styles, block content, and scripts into a complete page.
  *
- * @param props - The props for the component..
- * @param props.getTemplateData - A async callback to get template styles and content.
- * @param props.children - The block content to render.
+ * @param {Object}                                props                 The props for the component.
+ * @param {TemplateRendererProps.getTemplateData} props.getTemplateData A async callback to get template styles and content.
+ * @param {TemplateRendererProps.children}        props.children        The block content to render.
+ *
  * @return A complete HTML document structure.
  */
 export async function TemplateRenderer( {

--- a/packages/next/src/template-renderer/template-head.tsx
+++ b/packages/next/src/template-renderer/template-head.tsx
@@ -4,8 +4,9 @@ import { type TemplateHeadProps } from '@snapwp/core';
 /**
  * Renders the head section with additional stylesheets for a template.
  *
- * @param props - The props for the component.
- * @param props.stylesheets - An array of additional stylesheets and inline styles.
+ * @param {Object}                        props             The props for the component.
+ * @param {TemplateHeadProps.stylesheets} props.stylesheets An array of additional stylesheets and inline styles.
+ *
  * @return A head element containing the provided styles and links.
  */
 export function TemplateHead( { stylesheets }: TemplateHeadProps ) {

--- a/packages/next/src/template-renderer/template-scripts.tsx
+++ b/packages/next/src/template-renderer/template-scripts.tsx
@@ -8,8 +8,9 @@ import { getConfig } from '@snapwp/core/config';
 /**
  * Renders a list of script elements from a given array of script data.
  *
- * @param props - The props for the component.
- * @param props.scripts - Array of script objects to be rendered.
+ * @param {Object}                     props         The props for the component.
+ * @param {Array<EnqueuedScriptProps>} props.scripts Array of script objects to be rendered.
+ *
  * @return A collection of `<Script />` components.
  */
 const ScriptMap = ( { scripts }: { scripts: EnqueuedScriptProps[] } ) => (
@@ -29,8 +30,9 @@ const ScriptMap = ( { scripts }: { scripts: EnqueuedScriptProps[] } ) => (
 /**
  * Generates and renders the import map for script modules.
  *
- * @param props - The props for the component.
- * @param props.scriptModules - Array of script module objects to generate import map from.
+ * @param {Object}                   props               The props for the component.
+ * @param {Array<ScriptModuleProps>} props.scriptModules Array of script module objects to generate an import map from.
+ *
  * @return A Script component containing the import map if dependencies exist.
  */
 const ImportMap = ( {
@@ -77,8 +79,9 @@ const ImportMap = ( {
 /**
  * Renders a list of script module elements from a given array of script module data.
  *
- * @param props - The props for the component.
- * @param props.scriptModules - Array of script module objects to be rendered.
+ * @param {Object}                   props               The props for the component.
+ * @param {Array<ScriptModuleProps>} props.scriptModules Array of script module objects to be rendered.
+ *
  * @return A collection of `<ScriptModule />` components.
  */
 const ScriptModuleMap = ( {
@@ -157,10 +160,11 @@ const ScriptModuleMap = ( {
 /**
  * Renders a list of scripts.
  *
- * @param props - The props for the component.
- * @param props.scripts - Array of script objects to be included in the page.
- * @param props.children - The children elements to be rendered.
- * @param props.scriptModules - Array of script module objects to be included in the page.
+ * @param {Object}                               props               The props for the component.
+ * @param {Array<EnqueuedScriptProps>|undefined} props.scripts       Array of script objects to be included in the page.
+ * @param {ReactNode}                            props.children      The children elements to be rendered.
+ * @param {Array<ScriptModuleProps>|undefined}   props.scriptModules Array of script module objects to be included in the page.
+ *
  * @return A collection of script elements.
  */
 export function TemplateScripts( {

--- a/packages/query/src/query-engine/index.ts
+++ b/packages/query/src/query-engine/index.ts
@@ -89,8 +89,10 @@ export class QueryEngine {
 	};
 
 	/**
-	 * Fetches blocks, scripts and styles for the given uri.
-	 * @param uri - The URL of the seed node.
+	 * Fetches blocks, scripts, and styles for the given uri.
+	 *
+	 * @param {string} uri The URL of the seed node.
+	 *
 	 * @return The template data fetched for the uri.
 	 */
 	static getTemplateData = async ( uri: string ) => {
@@ -130,7 +132,7 @@ export class QueryEngine {
 /**
  * Logs the Apollo errors.
  *
- * @param error - The Apollo error.
+ * @param {ApolloError} error The Apollo error.
  */
 const logApolloErrors = ( error: ApolloError ) => {
 	// If there are graphQLErrors log them.
@@ -152,7 +154,7 @@ const logApolloErrors = ( error: ApolloError ) => {
 /**
  * Returns the network error message.
  *
- * @param networkError - The network error.
+ * @param {Error|ServerParseError|ServerError} networkError The network error.
  *
  * @return The network error message.
  */

--- a/packages/query/src/utils/parse-global-styles.ts
+++ b/packages/query/src/utils/parse-global-styles.ts
@@ -9,7 +9,7 @@ import type { GetGlobalStylesQuery } from '@graphqlTypes/graphql';
 /**
  * Parses template query data into props for rendering a template.
  *
- * @param queryData - The data fetched from the template query.
+ * @param {ApolloQueryResult<GetGlobalStylesQuery>} queryData The data fetched from the template query.
  *
  * @throws Throws an error if the query data is missing or invalid.
  *

--- a/packages/query/src/utils/parse-template.ts
+++ b/packages/query/src/utils/parse-template.ts
@@ -12,9 +12,9 @@ import type { GetCurrentTemplateQuery } from '@graphqlTypes/graphql';
 /**
  * Parses template query data into props for rendering a template.
  *
- * @param queryData - The data fetched from the template query.
- * @param wordpressUrl - The base URL of the WordPress site.
- * @param uri - The URI of the template.
+ * @param {ApolloQueryResult<GetCurrentTemplateQuery>} queryData    The data fetched from the template query.
+ * @param {string}                                     wordpressUrl The base URL of the WordPress site.
+ * @param {string}                                     uri          The URI of the template.
  *
  * @return An object containing parsed template data.
  */
@@ -57,7 +57,7 @@ export default function parseQueryResult(
 /**
  * Gets and validates the body classes from the query data.
  *
- * @param templateByUri The template data fetched for the uri.
+ * @param {GetCurrentTemplateQuery.templateByUri} templateByUri The template data fetched for the uri.
  *
  * @return The body classes.
  */
@@ -82,8 +82,8 @@ function parseBodyClasses(
 /**
  * Gets and validates the enqueued scripts from the query data.
  *
- * @param templateByUri The template data fetched for the uri.
- * @param wordpressUrl The base URL of the WordPress site.
+ * @param {GetCurrentTemplateQuery.templateByUri} templateByUri The template data fetched for the uri.
+ * @param {string}                                wordpressUrl  The base URL of the WordPress site.
  *
  * @return The enqueued scripts.
  */
@@ -107,7 +107,7 @@ function parseEnqueuedScripts(
 /**
  * Gets and validates the editor blocks from the query data.
  *
- * @param templateByUri The template data fetched for the uri.
+ * @param {GetCurrentTemplateQuery.templateByUri} templateByUri The template data fetched for the uri.
  *
  * @return The editor blocks.
  */
@@ -132,8 +132,8 @@ function parseEditorBlocks(
 /**
  * Gets and validates the enqueued stylesheets from the query data.
  *
- * @param wordpressUrl The base URL of the WordPress site.
- * @param templateByUri The template data fetched for the uri.
+ * @param {string}                                wordpressUrl  The base URL of the WordPress site.
+ * @param {GetCurrentTemplateQuery.templateByUri} templateByUri The template data fetched for the uri.
  *
  * @return The enqueued stylesheets.
  */
@@ -154,8 +154,8 @@ function parseEnqueuedStylesheets(
 /**
  * Gets and validates the script modules from the query data.
  *
- * @param templateByUri The template data fetched for the uri.
- * @param wordpressUrl The base URL of the WordPress site.
+ * @param {GetCurrentTemplateQuery.templateByUri} templateByUri The template data fetched for the uri.
+ * @param {string}                                wordpressUrl  The base URL of the WordPress site.
  *
  * @return The script modules.
  */


### PR DESCRIPTION
## What
- This PR enforces parameter type in function documentation by adding [jsdoc/require-param-type](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/.README/rules/require-param-type.md) eslint rule.

### Related Issue(s):
- https://github.com/rtCamp/headless/issues/250

## Testing Instructions
- Run `npm install` && `npm run lint`.

## Additional Info
- As this PR fixes the codebase, we won't be getting any `eslint` errors.


## Checklist

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
