### PR TITLE
refactor!: Change `location` to `groupLocation` for script placement enum type

### DIFF
--- a/.changeset/fluffy-crabs-rhyme.md
+++ b/.changeset/fluffy-crabs-rhyme.md
@@ -1,7 +1,7 @@
 ---
-"@snapwp/query": patch
-"@snapwp/core": patch
-"@snapwp/next": patch
+"@snapwp/query": minor
+"@snapwp/core": minor
+"@snapwp/next": minor
 ---
 
-Refactor: Change location to groupLocation for script placement enum type
+refactor!: Change `location` to `groupLocation` for script placement enum type

--- a/.changeset/fluffy-crabs-rhyme.md
+++ b/.changeset/fluffy-crabs-rhyme.md
@@ -1,0 +1,7 @@
+---
+"@snapwp/query": patch
+"@snapwp/core": patch
+"@snapwp/next": patch
+---
+
+Refactor: Change location to groupLocation for script placement enum type

--- a/packages/core/src/props/index.ts
+++ b/packages/core/src/props/index.ts
@@ -24,15 +24,12 @@ export type StyleSheetProps = {
 	handle?: string | null;
 };
 
-// Define enum for script loading locations to match backend changes
-export type ScriptLoadingGroupLocationEnum = 'HEADER' | 'FOOTER';
-
 export type EnqueuedScriptProps = {
 	after?: ( string | null )[] | null;
 	before?: ( string | null )[] | null;
 	extraData?: string | null;
 	handle?: string | null;
-	groupLocation?: ScriptLoadingGroupLocationEnum | null;
+	groupLocation?: 'HEADER' | 'FOOTER' | null;
 	src?: string | null;
 	loadingStrategy?: 'ASYNC' | 'DEFER' | null;
 	version?: string | null;

--- a/packages/core/src/props/index.ts
+++ b/packages/core/src/props/index.ts
@@ -24,12 +24,16 @@ export type StyleSheetProps = {
 	handle?: string | null;
 };
 
+// Define enum for script loading locations to match backend changes
+export type ScriptLoadingGroupLocationEnum = 'HEADER' | 'FOOTER';
+
 export type EnqueuedScriptProps = {
 	after?: ( string | null )[] | null;
 	before?: ( string | null )[] | null;
 	extraData?: string | null;
 	handle?: string | null;
-	location?: string | null;
+	// Updated from 'location' to 'groupLocation'
+	groupLocation?: ScriptLoadingGroupLocationEnum | null;
 	src?: string | null;
 	loadingStrategy?: 'ASYNC' | 'DEFER' | null;
 	version?: string | null;

--- a/packages/core/src/props/index.ts
+++ b/packages/core/src/props/index.ts
@@ -32,7 +32,6 @@ export type EnqueuedScriptProps = {
 	before?: ( string | null )[] | null;
 	extraData?: string | null;
 	handle?: string | null;
-	// Updated from 'location' to 'groupLocation'
 	groupLocation?: ScriptLoadingGroupLocationEnum | null;
 	src?: string | null;
 	loadingStrategy?: 'ASYNC' | 'DEFER' | null;

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -137,7 +137,7 @@ export default function ScriptExample() {
                 src="https://example.com/main.js"
                 handle="example-main-script"
                 loadingStrategy="ASYNC"
-                groupLocation="header"
+                groupLocation="HEADER"
             />
         </div>
     );

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -121,7 +121,7 @@ The Script component is a flexible wrapper around Next.js' `<Script>`, allowing 
 -   `extraData`: Extra information needed for the script
 -   `handle`: A unique identifier for the script.
 -   `loadingStrategy`: Determines how the script is loaded (ASYNC, DEFER).
--   `location`: Defines where the script should be loaded (header or footer).
+-   `groupLocation`: Defines where the script should be loaded (header or footer).
 -   `src`: The source of the asset.
 
 This component ensures better script management, allowing inline execution before or after the main script while supporting external script sources.
@@ -137,7 +137,7 @@ export default function ScriptExample() {
                 src="https://example.com/main.js"
                 handle="example-main-script"
                 loadingStrategy="ASYNC"
-                location="header"
+                groupLocation="header"
             />
         </div>
     );

--- a/packages/next/src/components/script.tsx
+++ b/packages/next/src/components/script.tsx
@@ -1,16 +1,13 @@
 import React, { type PropsWithoutRef } from 'react';
 import NextScript, { type ScriptProps } from 'next/script';
 
-// Define script location enum to match backend GraphQL schema changes
-export type ScriptLoadingGroupLocationEnum = 'HEADER' | 'FOOTER';
-
 interface ScriptInterface {
 	after?: ( string | null )[] | null;
 	before?: ( string | null )[] | null;
 	extraData?: string | null;
 	handle?: string | null;
 	loadingStrategy?: 'ASYNC' | 'DEFER' | null;
-	groupLocation?: ScriptLoadingGroupLocationEnum | null;
+	groupLocation?: 'HEADER' | 'FOOTER' | null;
 	src?: string | null;
 }
 

--- a/packages/next/src/components/script.tsx
+++ b/packages/next/src/components/script.tsx
@@ -1,13 +1,16 @@
 import React, { type PropsWithoutRef } from 'react';
 import NextScript, { type ScriptProps } from 'next/script';
 
+// Define script location enum to match backend GraphQL schema changes
+export type ScriptLoadingGroupLocationEnum = 'HEADER' | 'FOOTER';
+
 interface ScriptInterface {
 	after?: ( string | null )[] | null;
 	before?: ( string | null )[] | null;
 	extraData?: string | null;
 	handle?: string | null;
 	loadingStrategy?: 'ASYNC' | 'DEFER' | null;
-	location?: string | null;
+	groupLocation?: ScriptLoadingGroupLocationEnum | null;
 	src?: string | null;
 }
 
@@ -20,7 +23,7 @@ interface ScriptInterface {
  * @param props.extraData - Additional data to be included in the script.
  * @param props.handle - The handle for the script.
  * @param props.loadingStrategy - The loading strategy for the script (async or defer).
- * @param props.location - The location where the script should be loaded.
+ * @param props.groupLocation - The location where the script should be loaded.
  * @param props.src - The source URL for the script.
  * @return The rendered script element.
  */
@@ -29,7 +32,7 @@ export default function Script( {
 	before,
 	extraData,
 	handle,
-	location,
+	groupLocation,
 	src,
 	loadingStrategy,
 	...props
@@ -41,7 +44,7 @@ export default function Script( {
 
 	// Determine the strategy for the script.
 	const nextStrategy =
-		location === 'header' ? 'beforeInteractive' : 'afterInteractive';
+		groupLocation === 'HEADER' ? 'beforeInteractive' : 'afterInteractive';
 
 	// Generate an inline script for additional data if provided.
 	const ExtraDataScript = extraData && (

--- a/packages/next/src/template-renderer/template-scripts.tsx
+++ b/packages/next/src/template-renderer/template-scripts.tsx
@@ -173,9 +173,9 @@ export function TemplateScripts( {
 } > ) {
 	// Separate scripts by location
 	const headerScripts =
-		scripts?.filter( ( script ) => script.location === 'header' ) ?? [];
+		scripts?.filter( ( script ) => script.location === 'HEADER' ) ?? [];
 	const footerScripts =
-		scripts?.filter( ( script ) => script.location === 'footer' ) ?? [];
+		scripts?.filter( ( script ) => script.location === 'FOOTER' ) ?? [];
 
 	return (
 		<>

--- a/packages/next/src/template-renderer/template-scripts.tsx
+++ b/packages/next/src/template-renderer/template-scripts.tsx
@@ -173,9 +173,11 @@ export function TemplateScripts( {
 } > ) {
 	// Separate scripts by location
 	const headerScripts =
-		scripts?.filter( ( script ) => script.groupLocation === 'HEADER' ) ?? [];
+		scripts?.filter( ( script ) => script.groupLocation === 'HEADER' ) ??
+		[];
 	const footerScripts =
-		scripts?.filter( ( script ) => script.groupLocation === 'FOOTER' ) ?? [];
+		scripts?.filter( ( script ) => script.groupLocation === 'FOOTER' ) ??
+		[];
 
 	return (
 		<>

--- a/packages/next/src/template-renderer/template-scripts.tsx
+++ b/packages/next/src/template-renderer/template-scripts.tsx
@@ -173,9 +173,9 @@ export function TemplateScripts( {
 } > ) {
 	// Separate scripts by location
 	const headerScripts =
-		scripts?.filter( ( script ) => script.location === 'HEADER' ) ?? [];
+		scripts?.filter( ( script ) => script.groupLocation === 'HEADER' ) ?? [];
 	const footerScripts =
-		scripts?.filter( ( script ) => script.location === 'FOOTER' ) ?? [];
+		scripts?.filter( ( script ) => script.groupLocation === 'FOOTER' ) ?? [];
 
 	return (
 		<>

--- a/packages/query/src/queries/get-current-template.graphql
+++ b/packages/query/src/queries/get-current-template.graphql
@@ -16,7 +16,7 @@ query GetCurrentTemplate($uri: String!) {
 				extraData
 				handle
 				id
-				location
+				groupLocation
 				src
 				loadingStrategy: strategy
 				version


### PR DESCRIPTION
## What
Change `location` property to `groupLocation` with proper enum type to match backend GraphQL schema updates

## Why
This PR updates the frontend code to be compatible with the backend changes that switched from using `location: String` to `groupLocation: ScriptLoadingGroupLocationEnum`

### Related Issue(s):
- Part of: rtCamp/snapwp

## How
- Created a `ScriptLoadingGroupLocationEnum` type with 'HEADER' and 'FOOTER' values
- Updated prop interfaces to use `groupLocation` instead of `location`
- Updated component logic to use the new enum values
- Modified GraphQL query to fetch `groupLocation` instead of `location`
- Updated documentation to reflect the new property name

## Testing Instructions
1. Add a script with `groupLocation="HEADER"` in a component
2. Verify script loads in the header with 'beforeInteractive' strategy
3. Add a script with `groupLocation="FOOTER"` in a component
4. Verify script loads in the footer with 'afterInteractive' strategy
5. Check that the GraphQL query correctly retrieves scripts with their locations

## Additional Info
This change includes a changeset file (`poor-lands-study.md`) to document the patch version update.

## Checklist
- [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (ESLint, tsc, prettier etc.).
- [x] My code has detailed inline documentation.
- [ ] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation as needed.
- [x] I have added a changeset for this PR using `npm run changeset`.