### PR TITLE
chore: Add `react/jsx-boolean-value` eslint rule to codebase

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -70,6 +70,8 @@ module.exports = {
 
 		// Restrict the use of empty functions.
 		'no-empty-function': 'error',
+
+		'react/jsx-boolean-value': 'error',
 	},
 	overrides: [
 		{

--- a/packages/next/src/root-layout/index.tsx
+++ b/packages/next/src/root-layout/index.tsx
@@ -26,7 +26,7 @@ export async function RootLayout( {
 				<GlobalHead { ...globalHeadProps } />
 			</head>
 			{ /* suppressHydrationWarning is added to suppress warnings when classes for body are updated on the client */ }
-			<body suppressHydrationWarning={ true }>{ children }</body>
+			<body suppressHydrationWarning>{ children }</body>
 		</html>
 	);
 }


### PR DESCRIPTION
## What
- This PR implements [react/jsx-boolean-value](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) forcing to omit the true value passed to JSX component's prop to maintain consistency in code. (JFI: if a prop requires a boolean value & if no value is passed, by default it is true [[Ref](https://www.freecodecamp.org/news/react-props-cheatsheet/#:~:text=React%20props%20passed%20with%20just%20their%20name%20have%20a%20value%20of%20true)])

### Related Issue(s):
- https://github.com/rtCamp/headless/issues/250

## Testing Instructions
- Run `npm install` && `npm run lint`.

## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->


## Additional Info
- As this PR fixes the codebase, we won't be getting any `eslint` errors.


## Checklist

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [x] I have added unit tests to verify the code works as intended.
-   [ ] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
