### PR TITLE
chore: Add `react/jsx-curly-brace-presence` eslint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -71,6 +71,12 @@ module.exports = {
 
 		// Restrict the use of empty functions.
 		'no-empty-function': 'error',
+
+		// Disallow unnecessary JSX curly braces when literals alone are enough.
+		'react/jsx-curly-brace-presence': [
+			'error',
+			{ children: 'never', props: 'never' },
+		],
 	},
 	overrides: [
 		{

--- a/packages/next/src/root-layout/global-head.tsx
+++ b/packages/next/src/root-layout/global-head.tsx
@@ -21,7 +21,7 @@ export function GlobalHead( {
 		<>
 			{ globalStylesheet && (
 				<style
-					id={ 'stylesheet' }
+					id="stylesheet"
 					dangerouslySetInnerHTML={ { __html: globalStylesheet } }
 				></style>
 			) }
@@ -32,7 +32,7 @@ export function GlobalHead( {
 
 			{ customCss && (
 				<style
-					id={ 'customCSS' }
+					id="customCSS"
 					dangerouslySetInnerHTML={ { __html: customCss } }
 				></style>
 			) }


### PR DESCRIPTION
## What
- This PR will add [react/jsx-curly-brace-presence](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md) rule preventing unnecessary JSX curly braces when literals alone are enough.

### Related Issue(s):
- https://github.com/rtCamp/headless/issues/250

## Testing Instructions
- Run `npm install` && `npm run lint`.

## Additional Info
- As this PR fixes the codebase, we won't be getting any `eslint` errors.

## Checklist

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
