### PR TITLE
dev: Add `import/default` to `.js`, `.jsx`, `.ts` & `.tsx` files

### DIFF
--- a/.changeset/swift-paths-change.md
+++ b/.changeset/swift-paths-change.md
@@ -1,0 +1,8 @@
+---
+"@snapwp/blocks": patch
+"@snapwp/types": patch
+"@snapwp/core": patch
+"@snapwp/next": patch
+---
+
+Update jsx compiler

--- a/.changeset/swift-paths-change.md
+++ b/.changeset/swift-paths-change.md
@@ -5,4 +5,4 @@
 "@snapwp/next": patch
 ---
 
-Update jsx compiler
+chore: Enforce "import/default" eslint ruleset.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -95,7 +95,6 @@ module.exports = {
 						},
 					},
 				],
-				'import/default': [ 'off' ],
 			},
 		},
 		// Disable n/no-process-env for `codegen.ts` file.

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -34,7 +34,7 @@
 		"verbatimModuleSyntax": true,
 
 		// Language and Environment
-		"jsx": "react",
+		"jsx": "react-jsx",
 		"lib": [ "ES2022", "DOM" ],
 		"moduleDetection": "force",
 		"target": "ES2022",

--- a/package.json
+++ b/package.json
@@ -93,5 +93,6 @@
 	"dependencies": {
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0"
-	}
+	},
+	"packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,5 @@
 	"dependencies": {
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0"
-	},
-	"packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+	}
 }

--- a/packages/blocks/src/blocks/core-audio.tsx
+++ b/packages/blocks/src/blocks/core-audio.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-audio.tsx
+++ b/packages/blocks/src/blocks/core-audio.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-button.tsx
+++ b/packages/blocks/src/blocks/core-button.tsx
@@ -1,4 +1,4 @@
-import { type ButtonHTMLAttributes } from 'react';
+import type { ButtonHTMLAttributes } from 'react';
 import { cn, getStylesFromAttributes, replaceHostUrl } from '@snapwp/core';
 import { getConfig } from '@snapwp/core/config';
 import { Link, Parse } from '@snapwp/next';

--- a/packages/blocks/src/blocks/core-button.tsx
+++ b/packages/blocks/src/blocks/core-button.tsx
@@ -1,4 +1,5 @@
-import React, { type ButtonHTMLAttributes } from 'react';
+import * as React from 'react';
+import { type ButtonHTMLAttributes } from 'react';
 import { cn, getStylesFromAttributes, replaceHostUrl } from '@snapwp/core';
 import { getConfig } from '@snapwp/core/config';
 import { Link, Parse } from '@snapwp/next';

--- a/packages/blocks/src/blocks/core-button.tsx
+++ b/packages/blocks/src/blocks/core-button.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { type ButtonHTMLAttributes } from 'react';
 import { cn, getStylesFromAttributes, replaceHostUrl } from '@snapwp/core';
 import { getConfig } from '@snapwp/core/config';

--- a/packages/blocks/src/blocks/core-buttons.tsx
+++ b/packages/blocks/src/blocks/core-buttons.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { cn, getStylesFromAttributes } from '@snapwp/core';
 import type {
 	CoreButtons as CoreButtonsType,

--- a/packages/blocks/src/blocks/core-buttons.tsx
+++ b/packages/blocks/src/blocks/core-buttons.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { cn, getStylesFromAttributes } from '@snapwp/core';
 import type {
 	CoreButtons as CoreButtonsType,

--- a/packages/blocks/src/blocks/core-code.tsx
+++ b/packages/blocks/src/blocks/core-code.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { getStylesFromAttributes } from '@snapwp/core';
 import { Parse } from '@snapwp/next';
 import type { CoreCode as CoreCodeType, CoreCodeProps } from '@snapwp/types';

--- a/packages/blocks/src/blocks/core-code.tsx
+++ b/packages/blocks/src/blocks/core-code.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { getStylesFromAttributes } from '@snapwp/core';
 import { Parse } from '@snapwp/next';
 import type { CoreCode as CoreCodeType, CoreCodeProps } from '@snapwp/types';

--- a/packages/blocks/src/blocks/core-column.tsx
+++ b/packages/blocks/src/blocks/core-column.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { cn, getStylesFromAttributes } from '@snapwp/core';
 import type {
 	CoreColumn as CoreColumnType,

--- a/packages/blocks/src/blocks/core-column.tsx
+++ b/packages/blocks/src/blocks/core-column.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { cn, getStylesFromAttributes } from '@snapwp/core';
 import type {
 	CoreColumn as CoreColumnType,

--- a/packages/blocks/src/blocks/core-columns.tsx
+++ b/packages/blocks/src/blocks/core-columns.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { cn, getStylesFromAttributes } from '@snapwp/core';
 import type {
 	CoreColumns as CoreColumnsType,

--- a/packages/blocks/src/blocks/core-columns.tsx
+++ b/packages/blocks/src/blocks/core-columns.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { cn, getStylesFromAttributes } from '@snapwp/core';
 import type {
 	CoreColumns as CoreColumnsType,

--- a/packages/blocks/src/blocks/core-cover.tsx
+++ b/packages/blocks/src/blocks/core-cover.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { type ComponentProps } from 'react';
 import {
 	getStylesFromAttributes,

--- a/packages/blocks/src/blocks/core-cover.tsx
+++ b/packages/blocks/src/blocks/core-cover.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps } from 'react';
+import type { ComponentProps } from 'react';
 import {
 	getStylesFromAttributes,
 	findElementAndGetClassNames,

--- a/packages/blocks/src/blocks/core-cover.tsx
+++ b/packages/blocks/src/blocks/core-cover.tsx
@@ -1,4 +1,5 @@
-import React, { type ComponentProps } from 'react';
+import * as React from 'react';
+import { type ComponentProps } from 'react';
 import {
 	getStylesFromAttributes,
 	findElementAndGetClassNames,

--- a/packages/blocks/src/blocks/core-details.tsx
+++ b/packages/blocks/src/blocks/core-details.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-details.tsx
+++ b/packages/blocks/src/blocks/core-details.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-file.tsx
+++ b/packages/blocks/src/blocks/core-file.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-file.tsx
+++ b/packages/blocks/src/blocks/core-file.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-freeform.tsx
+++ b/packages/blocks/src/blocks/core-freeform.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Parse } from '@snapwp/next';
 import type {
 	CoreFreeform as CoreFreeformType,

--- a/packages/blocks/src/blocks/core-freeform.tsx
+++ b/packages/blocks/src/blocks/core-freeform.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Parse } from '@snapwp/next';
 import type {
 	CoreFreeform as CoreFreeformType,

--- a/packages/blocks/src/blocks/core-gallery.tsx
+++ b/packages/blocks/src/blocks/core-gallery.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-gallery.tsx
+++ b/packages/blocks/src/blocks/core-gallery.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-group.tsx
+++ b/packages/blocks/src/blocks/core-group.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { createElement } from 'react';
 import {
 	cn,

--- a/packages/blocks/src/blocks/core-group.tsx
+++ b/packages/blocks/src/blocks/core-group.tsx
@@ -1,4 +1,5 @@
-import React, { createElement } from 'react';
+import * as React from 'react';
+import { createElement } from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-heading.tsx
+++ b/packages/blocks/src/blocks/core-heading.tsx
@@ -1,4 +1,5 @@
-import React, { type JSX } from 'react';
+import * as React from 'react';
+import { type JSX } from 'react';
 import { getStylesFromAttributes } from '@snapwp/core';
 import { Parse } from '@snapwp/next';
 import type {

--- a/packages/blocks/src/blocks/core-heading.tsx
+++ b/packages/blocks/src/blocks/core-heading.tsx
@@ -1,4 +1,4 @@
-import { type JSX } from 'react';
+import type { JSX } from 'react';
 import { getStylesFromAttributes } from '@snapwp/core';
 import { Parse } from '@snapwp/next';
 import type {

--- a/packages/blocks/src/blocks/core-heading.tsx
+++ b/packages/blocks/src/blocks/core-heading.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { type JSX } from 'react';
 import { getStylesFromAttributes } from '@snapwp/core';
 import { Parse } from '@snapwp/next';

--- a/packages/blocks/src/blocks/core-html.tsx
+++ b/packages/blocks/src/blocks/core-html.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Parse } from '@snapwp/next';
 import type { CoreHtml as CoreHtmlType, CoreHtmlProps } from '@snapwp/types';
 

--- a/packages/blocks/src/blocks/core-html.tsx
+++ b/packages/blocks/src/blocks/core-html.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Parse } from '@snapwp/next';
 import type { CoreHtml as CoreHtmlType, CoreHtmlProps } from '@snapwp/types';
 

--- a/packages/blocks/src/blocks/core-image.tsx
+++ b/packages/blocks/src/blocks/core-image.tsx
@@ -1,5 +1,5 @@
 import { decode } from 'html-entities';
-import { type ComponentProps, type CSSProperties } from 'react';
+import type { ComponentProps, CSSProperties } from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-image.tsx
+++ b/packages/blocks/src/blocks/core-image.tsx
@@ -1,5 +1,6 @@
 import { decode } from 'html-entities';
-import React, { type ComponentProps, type CSSProperties } from 'react';
+import * as React from 'react';
+import { type ComponentProps, type CSSProperties } from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-image.tsx
+++ b/packages/blocks/src/blocks/core-image.tsx
@@ -1,5 +1,4 @@
 import { decode } from 'html-entities';
-import * as React from 'react';
 import { type ComponentProps, type CSSProperties } from 'react';
 import {
 	cn,

--- a/packages/blocks/src/blocks/core-list-item.tsx
+++ b/packages/blocks/src/blocks/core-list-item.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-list-item.tsx
+++ b/packages/blocks/src/blocks/core-list-item.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-list.tsx
+++ b/packages/blocks/src/blocks/core-list.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { cn, getStylesFromAttributes } from '@snapwp/core';
 import type { CoreList as CoreListType, CoreListProps } from '@snapwp/types';
 

--- a/packages/blocks/src/blocks/core-list.tsx
+++ b/packages/blocks/src/blocks/core-list.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { cn, getStylesFromAttributes } from '@snapwp/core';
 import type { CoreList as CoreListType, CoreListProps } from '@snapwp/types';
 

--- a/packages/blocks/src/blocks/core-media-text.tsx
+++ b/packages/blocks/src/blocks/core-media-text.tsx
@@ -1,4 +1,5 @@
-import React, { type ComponentProps } from 'react';
+import * as React from 'react';
+import { type ComponentProps } from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-media-text.tsx
+++ b/packages/blocks/src/blocks/core-media-text.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { type ComponentProps } from 'react';
 import {
 	cn,

--- a/packages/blocks/src/blocks/core-media-text.tsx
+++ b/packages/blocks/src/blocks/core-media-text.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps } from 'react';
+import type { ComponentProps } from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-paragraph.tsx
+++ b/packages/blocks/src/blocks/core-paragraph.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { getStylesFromAttributes } from '@snapwp/core';
 import { Parse } from '@snapwp/next';
 import type {

--- a/packages/blocks/src/blocks/core-paragraph.tsx
+++ b/packages/blocks/src/blocks/core-paragraph.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { getStylesFromAttributes } from '@snapwp/core';
 import { Parse } from '@snapwp/next';
 import type {

--- a/packages/blocks/src/blocks/core-pattern.tsx
+++ b/packages/blocks/src/blocks/core-pattern.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type {
 	CorePattern as CorePatternType,
 	CorePatternProps,

--- a/packages/blocks/src/blocks/core-pattern.tsx
+++ b/packages/blocks/src/blocks/core-pattern.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type {
 	CorePattern as CorePatternType,
 	CorePatternProps,

--- a/packages/blocks/src/blocks/core-post-content.tsx
+++ b/packages/blocks/src/blocks/core-post-content.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { cn, getClassNamesFromString } from '@snapwp/core';
 import type {
 	CorePostContent as CorePostContentType,

--- a/packages/blocks/src/blocks/core-post-content.tsx
+++ b/packages/blocks/src/blocks/core-post-content.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { cn, getClassNamesFromString } from '@snapwp/core';
 import type {
 	CorePostContent as CorePostContentType,

--- a/packages/blocks/src/blocks/core-preformatted.tsx
+++ b/packages/blocks/src/blocks/core-preformatted.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-preformatted.tsx
+++ b/packages/blocks/src/blocks/core-preformatted.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-pullquote.tsx
+++ b/packages/blocks/src/blocks/core-pullquote.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-pullquote.tsx
+++ b/packages/blocks/src/blocks/core-pullquote.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-quote.tsx
+++ b/packages/blocks/src/blocks/core-quote.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { getStylesFromAttributes } from '@snapwp/core';
 import { Parse } from '@snapwp/next';
 import type { CoreQuote as CoreQuoteType, CoreQuoteProps } from '@snapwp/types';

--- a/packages/blocks/src/blocks/core-quote.tsx
+++ b/packages/blocks/src/blocks/core-quote.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { getStylesFromAttributes } from '@snapwp/core';
 import { Parse } from '@snapwp/next';
 import type { CoreQuote as CoreQuoteType, CoreQuoteProps } from '@snapwp/types';

--- a/packages/blocks/src/blocks/core-separator.tsx
+++ b/packages/blocks/src/blocks/core-separator.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { getClassNamesFromString } from '@snapwp/core';
 import type {
 	CoreSeparator as CoreSeparatorType,

--- a/packages/blocks/src/blocks/core-separator.tsx
+++ b/packages/blocks/src/blocks/core-separator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { getClassNamesFromString } from '@snapwp/core';
 import type {
 	CoreSeparator as CoreSeparatorType,

--- a/packages/blocks/src/blocks/core-spacer.tsx
+++ b/packages/blocks/src/blocks/core-spacer.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-spacer.tsx
+++ b/packages/blocks/src/blocks/core-spacer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-template-part.tsx
+++ b/packages/blocks/src/blocks/core-template-part.tsx
@@ -1,4 +1,4 @@
-import { type JSX } from 'react';
+import type { JSX } from 'react';
 import { cn, getClassNamesFromString } from '@snapwp/core';
 import type {
 	CoreTemplatePart as CoreTemplatePartType,

--- a/packages/blocks/src/blocks/core-template-part.tsx
+++ b/packages/blocks/src/blocks/core-template-part.tsx
@@ -1,4 +1,5 @@
-import React, { type JSX } from 'react';
+import * as React from 'react';
+import { type JSX } from 'react';
 import { cn, getClassNamesFromString } from '@snapwp/core';
 import type {
 	CoreTemplatePart as CoreTemplatePartType,

--- a/packages/blocks/src/blocks/core-template-part.tsx
+++ b/packages/blocks/src/blocks/core-template-part.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { type JSX } from 'react';
 import { cn, getClassNamesFromString } from '@snapwp/core';
 import type {

--- a/packages/blocks/src/blocks/core-verse.tsx
+++ b/packages/blocks/src/blocks/core-verse.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-verse.tsx
+++ b/packages/blocks/src/blocks/core-verse.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-video.tsx
+++ b/packages/blocks/src/blocks/core-video.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/core-video.tsx
+++ b/packages/blocks/src/blocks/core-video.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
 	cn,
 	getClassNamesFromString,

--- a/packages/blocks/src/blocks/default.tsx
+++ b/packages/blocks/src/blocks/default.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Parse } from '@snapwp/next';
 import type { Default as DefaultType, DefaultProps } from '@snapwp/types';
 

--- a/packages/blocks/src/blocks/default.tsx
+++ b/packages/blocks/src/blocks/default.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Parse } from '@snapwp/next';
 import type { Default as DefaultType, DefaultProps } from '@snapwp/types';
 

--- a/packages/blocks/src/blocks/tests/core-audio.test.tsx
+++ b/packages/blocks/src/blocks/tests/core-audio.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import CoreAudio from '../core-audio';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';

--- a/packages/blocks/src/blocks/tests/core-audio.test.tsx
+++ b/packages/blocks/src/blocks/tests/core-audio.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import CoreAudio from '../core-audio';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';

--- a/packages/blocks/src/blocks/tests/core-button.test.tsx
+++ b/packages/blocks/src/blocks/tests/core-button.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CoreButton from '../core-button';

--- a/packages/blocks/src/blocks/tests/core-button.test.tsx
+++ b/packages/blocks/src/blocks/tests/core-button.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CoreButton from '../core-button';

--- a/packages/blocks/src/blocks/tests/core-buttons.test.tsx
+++ b/packages/blocks/src/blocks/tests/core-buttons.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CoreButtons from '../core-buttons';

--- a/packages/blocks/src/blocks/tests/core-buttons.test.tsx
+++ b/packages/blocks/src/blocks/tests/core-buttons.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import CoreButtons from '../core-buttons';

--- a/packages/blocks/src/editor-blocks-renderer/index.tsx
+++ b/packages/blocks/src/editor-blocks-renderer/index.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import BlockManager from '@/block-manager';
 import { getConfig } from '@snapwp/core/config';
 

--- a/packages/blocks/src/editor-blocks-renderer/index.tsx
+++ b/packages/blocks/src/editor-blocks-renderer/index.tsx
@@ -39,8 +39,10 @@ export default function EditorBlocksRenderer( {
 		delete props[ 'renderer' ];
 		delete props[ 'children' ];
 
+		const { key, ...properties } = props;
+
 		return (
-			<node.renderer { ...props }>
+			<node.renderer key={ key } { ...properties }>
 				{ node.children && node.children.map( renderNode ) }
 			</node.renderer>
 		);

--- a/packages/blocks/src/editor-blocks-renderer/index.tsx
+++ b/packages/blocks/src/editor-blocks-renderer/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import BlockManager from '@/block-manager';
 import { getConfig } from '@snapwp/core/config';
 

--- a/packages/core/src/config/tests/snapwp-config-manager.test.tsx
+++ b/packages/core/src/config/tests/snapwp-config-manager.test.tsx
@@ -7,7 +7,6 @@ import {
 	type SnapWPEnv,
 } from '@/config/snapwp-config-manager';
 const SnapWPConfigManager = _private.SnapWPConfigManager!;
-import * as React from 'react';
 
 /**
  * A mock React component used for testing block definitions.

--- a/packages/core/src/config/tests/snapwp-config-manager.test.tsx
+++ b/packages/core/src/config/tests/snapwp-config-manager.test.tsx
@@ -7,7 +7,7 @@ import {
 	type SnapWPEnv,
 } from '@/config/snapwp-config-manager';
 const SnapWPConfigManager = _private.SnapWPConfigManager!;
-import React from 'react';
+import * as React from 'react';
 
 /**
  * A mock React component used for testing block definitions.

--- a/packages/next/src/components/default-error.tsx
+++ b/packages/next/src/components/default-error.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import * as React from 'react';
-
 /**
  * Default error component.
  *

--- a/packages/next/src/components/default-error.tsx
+++ b/packages/next/src/components/default-error.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import * as React from 'react';
 
 /**
  * Default error component.

--- a/packages/next/src/components/font.tsx
+++ b/packages/next/src/components/font.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 /**
  * A wrapper for loading fonts dynamically using next/font.

--- a/packages/next/src/components/font.tsx
+++ b/packages/next/src/components/font.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 /**
  * A wrapper for loading fonts dynamically using next/font.
  *

--- a/packages/next/src/components/image.tsx
+++ b/packages/next/src/components/image.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react';
+import {
 	type CSSProperties,
 	type ImgHTMLAttributes,
 	type PropsWithoutRef,

--- a/packages/next/src/components/image.tsx
+++ b/packages/next/src/components/image.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	type CSSProperties,
 	type ImgHTMLAttributes,

--- a/packages/next/src/components/link.tsx
+++ b/packages/next/src/components/link.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react';
+import {
 	type AnchorHTMLAttributes,
 	type CSSProperties,
 	type PropsWithChildren,

--- a/packages/next/src/components/link.tsx
+++ b/packages/next/src/components/link.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	type AnchorHTMLAttributes,
 	type CSSProperties,

--- a/packages/next/src/components/script-module.tsx
+++ b/packages/next/src/components/script-module.tsx
@@ -5,7 +5,8 @@
  * This component ensures that all dependencies of a script module are loaded before the main script.
  * Dependencies are rendered as individual <Script /> components and are typically loaded asynchronously.
  */
-import React, { type PropsWithoutRef } from 'react';
+import * as React from 'react';
+import { type PropsWithoutRef } from 'react';
 import Script from 'next/script';
 
 interface ScriptModuleInterface {

--- a/packages/next/src/components/script-module.tsx
+++ b/packages/next/src/components/script-module.tsx
@@ -5,7 +5,7 @@
  * This component ensures that all dependencies of a script module are loaded before the main script.
  * Dependencies are rendered as individual <Script /> components and are typically loaded asynchronously.
  */
-import { type PropsWithoutRef } from 'react';
+import type { PropsWithoutRef } from 'react';
 import Script from 'next/script';
 
 interface ScriptModuleInterface {

--- a/packages/next/src/components/script-module.tsx
+++ b/packages/next/src/components/script-module.tsx
@@ -5,7 +5,6 @@
  * This component ensures that all dependencies of a script module are loaded before the main script.
  * Dependencies are rendered as individual <Script /> components and are typically loaded asynchronously.
  */
-import * as React from 'react';
 import { type PropsWithoutRef } from 'react';
 import Script from 'next/script';
 

--- a/packages/next/src/components/script.tsx
+++ b/packages/next/src/components/script.tsx
@@ -1,4 +1,5 @@
-import React, { type PropsWithoutRef } from 'react';
+import * as React from 'react';
+import { type PropsWithoutRef } from 'react';
 import NextScript, { type ScriptProps } from 'next/script';
 
 interface ScriptInterface {

--- a/packages/next/src/components/script.tsx
+++ b/packages/next/src/components/script.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { type PropsWithoutRef } from 'react';
 import NextScript, { type ScriptProps } from 'next/script';
 

--- a/packages/next/src/components/script.tsx
+++ b/packages/next/src/components/script.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithoutRef } from 'react';
+import type { PropsWithoutRef } from 'react';
 import NextScript, { type ScriptProps } from 'next/script';
 
 interface ScriptInterface {

--- a/packages/next/src/react-parser/index.tsx
+++ b/packages/next/src/react-parser/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Parser from 'html-react-parser';
 import { getConfig } from '@snapwp/core/config';
 import { defaultOptions } from './options';

--- a/packages/next/src/react-parser/index.tsx
+++ b/packages/next/src/react-parser/index.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import Parser from 'html-react-parser';
 import { getConfig } from '@snapwp/core/config';
 import { defaultOptions } from './options';

--- a/packages/next/src/react-parser/options.tsx
+++ b/packages/next/src/react-parser/options.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
 	domToReact,
 	Element,

--- a/packages/next/src/react-parser/options.tsx
+++ b/packages/next/src/react-parser/options.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
 	domToReact,
 	Element,

--- a/packages/next/src/root-layout/global-head.tsx
+++ b/packages/next/src/root-layout/global-head.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Fonts from '@/components/font';
 import { type GlobalHeadProps } from '@snapwp/core';
 

--- a/packages/next/src/root-layout/global-head.tsx
+++ b/packages/next/src/root-layout/global-head.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import Fonts from '@/components/font';
 import { type GlobalHeadProps } from '@snapwp/core';
 

--- a/packages/next/src/root-layout/index.tsx
+++ b/packages/next/src/root-layout/index.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 import { QueryEngine } from '@snapwp/query';
 import { GlobalHead } from './global-head';
 

--- a/packages/next/src/root-layout/index.tsx
+++ b/packages/next/src/root-layout/index.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { type PropsWithChildren } from 'react';
 import { QueryEngine } from '@snapwp/query';
 import { GlobalHead } from './global-head';

--- a/packages/next/src/root-layout/index.tsx
+++ b/packages/next/src/root-layout/index.tsx
@@ -1,4 +1,5 @@
-import React, { type PropsWithChildren } from 'react';
+import * as React from 'react';
+import { type PropsWithChildren } from 'react';
 import { QueryEngine } from '@snapwp/query';
 import { GlobalHead } from './global-head';
 

--- a/packages/next/src/template-renderer/index.tsx
+++ b/packages/next/src/template-renderer/index.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { type JSX } from 'react';
 import { headers } from 'next/headers';
 import { QueryEngine } from '@snapwp/query';

--- a/packages/next/src/template-renderer/index.tsx
+++ b/packages/next/src/template-renderer/index.tsx
@@ -1,4 +1,5 @@
-import React, { type JSX } from 'react';
+import * as React from 'react';
+import { type JSX } from 'react';
 import { headers } from 'next/headers';
 import { QueryEngine } from '@snapwp/query';
 import { TemplateHead } from './template-head';

--- a/packages/next/src/template-renderer/index.tsx
+++ b/packages/next/src/template-renderer/index.tsx
@@ -1,4 +1,4 @@
-import { type JSX } from 'react';
+import type { JSX } from 'react';
 import { headers } from 'next/headers';
 import { QueryEngine } from '@snapwp/query';
 import { TemplateHead } from './template-head';

--- a/packages/next/src/template-renderer/template-head.tsx
+++ b/packages/next/src/template-renderer/template-head.tsx
@@ -1,4 +1,5 @@
-import React, { Fragment } from 'react';
+import * as React from 'react';
+import { Fragment } from 'react';
 import { type TemplateHeadProps } from '@snapwp/core';
 
 /**

--- a/packages/next/src/template-renderer/template-head.tsx
+++ b/packages/next/src/template-renderer/template-head.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Fragment } from 'react';
 import { type TemplateHeadProps } from '@snapwp/core';
 

--- a/packages/next/src/template-renderer/template-head.tsx
+++ b/packages/next/src/template-renderer/template-head.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import { type TemplateHeadProps } from '@snapwp/core';
+import type { TemplateHeadProps } from '@snapwp/core';
 
 /**
  * Renders the head section with additional stylesheets for a template.

--- a/packages/next/src/template-renderer/template-scripts.tsx
+++ b/packages/next/src/template-renderer/template-scripts.tsx
@@ -1,8 +1,8 @@
-import { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 import NextScript from 'next/script';
 import Script from '@/components/script';
 import ScriptModule from '@/components/script-module';
-import { type EnqueuedScriptProps, type ScriptModuleProps } from '@snapwp/core';
+import type { EnqueuedScriptProps, ScriptModuleProps } from '@snapwp/core';
 import { getConfig } from '@snapwp/core/config';
 
 /**

--- a/packages/next/src/template-renderer/template-scripts.tsx
+++ b/packages/next/src/template-renderer/template-scripts.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { type PropsWithChildren } from 'react';
 import NextScript from 'next/script';
 import Script from '@/components/script';

--- a/packages/next/src/template-renderer/template-scripts.tsx
+++ b/packages/next/src/template-renderer/template-scripts.tsx
@@ -1,4 +1,5 @@
-import React, { type PropsWithChildren } from 'react';
+import * as React from 'react';
+import { type PropsWithChildren } from 'react';
 import NextScript from 'next/script';
 import Script from '@/components/script';
 import ScriptModule from '@/components/script-module';

--- a/packages/types/src/blocks/definitions.ts
+++ b/packages/types/src/blocks/definitions.ts
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 export type BlockDefinitions = {
 	[ key: string ]: React.ComponentType< any > | undefined | null;
 	default: React.ComponentType< any > | undefined | null;

--- a/packages/types/src/blocks/definitions.ts
+++ b/packages/types/src/blocks/definitions.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export type BlockDefinitions = {
 	[ key: string ]: React.ComponentType< any > | undefined | null;


### PR DESCRIPTION
## What
- This PR enforces [import/default](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md) rule on `.js`, `.jsx`, `.ts` & `.tsx` files by removing `"import/default": off`.
- As per this rule, if a default import is requested, the rule will report if there is no default export in the imported module.


### Related Issue(s):
- https://github.com/rtCamp/headless/issues/250

## Testing Instructions
- Run `npm install` && `npm run lint`.

## Additional Info
- As this PR fixes the codebase, we won't be getting any `eslint` errors.


## Checklist

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
