### PR TITLE
feat: Display error fallback when no editor blocks

### DIFF
--- a/.changeset/empty-pigs-fry.md
+++ b/.changeset/empty-pigs-fry.md
@@ -1,0 +1,5 @@
+---
+"@snapwp/next": minor
+---
+
+feat: Display error fallback when there are no editor blocks

--- a/.changeset/empty-pigs-fry.md
+++ b/.changeset/empty-pigs-fry.md
@@ -1,5 +1,5 @@
 ---
-"@snapwp/next": minor
+"@snapwp/next": patch
 ---
 
 feat: Display error fallback when there are no editor blocks

--- a/packages/next/src/components/default-error.tsx
+++ b/packages/next/src/components/default-error.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import { useRouter } from 'next/navigation';
 
 /**
  * Default error component.
@@ -20,17 +19,11 @@ export default function DefaultError( {
 	reset,
 }: {
 	error: Error & { digest?: string };
-	reset?: () => void;
+	reset: () => void;
 } ) {
-	const router = useRouter();
 	const unknownError =
 		'An unexpected error has occurred. Please check the logs for more details.';
 	const tryAgain = 'Try Again';
-	const handleReset =
-		reset ||
-		( () => {
-			router.refresh();
-		} );
 
 	let errorMessage = unknownError;
 
@@ -53,7 +46,7 @@ export default function DefaultError( {
 				{ error?.digest && error.digest }
 			</div>
 			<div className="buttons">
-				<button onClick={ handleReset }>{ tryAgain }</button>
+				<button onClick={ reset }>{ tryAgain }</button>
 			</div>
 			<style>{ `
 				.error-container {

--- a/packages/next/src/components/default-error.tsx
+++ b/packages/next/src/components/default-error.tsx
@@ -19,7 +19,7 @@ export default function DefaultError( {
 	reset,
 }: {
 	error: Error & { digest?: string };
-	reset: () => void;
+	reset?: () => void;
 } ) {
 	const unknownError =
 		'An unexpected error has occurred. Please check the logs for more details.';
@@ -45,9 +45,11 @@ export default function DefaultError( {
 			<div className="error-digest">
 				{ error?.digest && error.digest }
 			</div>
-			<div className="buttons">
-				<button onClick={ reset }>{ tryAgain }</button>
-			</div>
+			{ reset && (
+				<div className="buttons">
+					<button onClick={ reset }>{ tryAgain }</button>
+				</div>
+			) }
 			<style>{ `
 				.error-container {
 					display: flex;

--- a/packages/next/src/components/default-error.tsx
+++ b/packages/next/src/components/default-error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useRouter } from 'next/navigation';
 
 /**
  * Default error component.
@@ -21,9 +22,15 @@ export default function DefaultError( {
 	error: Error & { digest?: string };
 	reset?: () => void;
 } ) {
+	const router = useRouter();
 	const unknownError =
 		'An unexpected error has occurred. Please check the logs for more details.';
 	const tryAgain = 'Try Again';
+	const handleReset =
+		reset ||
+		( () => {
+			router.refresh();
+		} );
 
 	let errorMessage = unknownError;
 
@@ -45,11 +52,9 @@ export default function DefaultError( {
 			<div className="error-digest">
 				{ error?.digest && error.digest }
 			</div>
-			{ reset && (
-				<div className="buttons">
-					<button onClick={ reset }>{ tryAgain }</button>
-				</div>
-			) }
+			<div className="buttons">
+				<button onClick={ handleReset }>{ tryAgain }</button>
+			</div>
 			<style>{ `
 				.error-container {
 					display: flex;

--- a/packages/next/src/template-renderer/index.tsx
+++ b/packages/next/src/template-renderer/index.tsx
@@ -5,7 +5,6 @@ import { TemplateHead } from './template-head';
 import { TemplateScripts } from './template-scripts';
 import Script from 'next/script';
 import type { BlockData } from '@snapwp/types';
-import DefaultError from '@/components/default-error';
 
 export type TemplateRendererProps = {
 	getTemplateData?: ( typeof QueryEngine )[ 'getTemplateData' ];
@@ -31,6 +30,12 @@ export async function TemplateRenderer( {
 	const { editorBlocks, bodyClasses, stylesheets, scripts, scriptModules } =
 		await getTemplateData( pathname || '/' );
 
+	if ( ! editorBlocks ) {
+		throw new Error(
+			'Error: Unable to render content. `editorBlocks` is not defined. This may be due to missing template data or an issue with data fetching.'
+		);
+	}
+
 	// @todo: Script modules should load before styles to handle ordering properly
 	return (
 		<>
@@ -41,17 +46,7 @@ export async function TemplateRenderer( {
 			>
 				<main>
 					<div className="wp-site-blocks">
-						{ editorBlocks ? (
-							children( editorBlocks )
-						) : (
-							<DefaultError
-								error={
-									new Error(
-										'Error: Unable to render content. `editorBlocks` is not defined. This may be due to missing template data or an issue with data fetching.'
-									)
-								}
-							/>
-						) }
+						{ children( editorBlocks ) }
 					</div>
 				</main>
 			</TemplateScripts>

--- a/packages/next/src/template-renderer/index.tsx
+++ b/packages/next/src/template-renderer/index.tsx
@@ -30,7 +30,7 @@ export async function TemplateRenderer( {
 	const { editorBlocks, bodyClasses, stylesheets, scripts, scriptModules } =
 		await getTemplateData( pathname || '/' );
 
-	if ( ! editorBlocks || editorBlocks.length === 0 ) {
+	if ( ! editorBlocks?.length ) {
 		throw new Error(
 			'Error: Unable to render content. `editorBlocks` is not defined. This may be due to missing template data or an issue with data fetching.'
 		);

--- a/packages/next/src/template-renderer/index.tsx
+++ b/packages/next/src/template-renderer/index.tsx
@@ -5,6 +5,7 @@ import { TemplateHead } from './template-head';
 import { TemplateScripts } from './template-scripts';
 import Script from 'next/script';
 import type { BlockData } from '@snapwp/types';
+import DefaultError from '@/components/default-error';
 
 export type TemplateRendererProps = {
 	getTemplateData?: ( typeof QueryEngine )[ 'getTemplateData' ];
@@ -40,8 +41,17 @@ export async function TemplateRenderer( {
 			>
 				<main>
 					<div className="wp-site-blocks">
-						{ /** TODO: fallback if editorBlocks isn't defined. */ }
-						{ editorBlocks && children( editorBlocks ) }
+						{ editorBlocks ? (
+							children( editorBlocks )
+						) : (
+							<DefaultError
+								error={
+									new Error(
+										'Error: Unable to render content. `editorBlocks` is not defined. This may be due to missing template data or an issue with data fetching.'
+									)
+								}
+							/>
+						) }
 					</div>
 				</main>
 			</TemplateScripts>

--- a/packages/next/src/template-renderer/index.tsx
+++ b/packages/next/src/template-renderer/index.tsx
@@ -30,7 +30,7 @@ export async function TemplateRenderer( {
 	const { editorBlocks, bodyClasses, stylesheets, scripts, scriptModules } =
 		await getTemplateData( pathname || '/' );
 
-	if ( ! editorBlocks ) {
+	if ( ! editorBlocks || editorBlocks.length === 0 ) {
 		throw new Error(
 			'Error: Unable to render content. `editorBlocks` is not defined. This may be due to missing template data or an issue with data fetching.'
 		);


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR displays an error when `editorBlocks` are not defined.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
Currently, no message is displayed when editorBlocks is undefined.


### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->
https://github.com/orgs/rtCamp/projects/141/views/10?pane=issue&itemId=99060513

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
The `DefaultError` component is used to display this message: 'Error: Unable to render content. `editorBlocks` is not defined. This may be due to missing template data or an issue with data fetching.'


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->


## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->
![image](https://github.com/user-attachments/assets/10849682-d1f9-4898-9763-ba47e00ee32c)


## Additional Info
<!-- Please include any relevant logs, error output, etc -->


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [ ] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [ ] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
