### PR TITLE
fix: allow remotePatterns to be overridden

### DIFF
--- a/.changeset/fair-carrots-invite.md
+++ b/.changeset/fair-carrots-invite.md
@@ -2,4 +2,4 @@
 "@snapwp/next": patch
 ---
 
-Bug-Fix: remote patterns in users config being ignored
+fix: remote patterns in users config being ignored

--- a/.changeset/fair-carrots-invite.md
+++ b/.changeset/fair-carrots-invite.md
@@ -1,0 +1,5 @@
+---
+"@snapwp/next": patch
+---
+
+Bug-Fix: remote patterns in users config being ignored

--- a/packages/next/src/config/with-snap-wp.ts
+++ b/packages/next/src/config/with-snap-wp.ts
@@ -107,10 +107,7 @@ const withSnapWP = async ( nextConfig?: NextConfig ): Promise< NextConfig > => {
 	const homeUrl = new URL( getConfig().homeUrl );
 
 	const userImages = nextConfig && nextConfig.images ? nextConfig.images : {};
-	const userRemotePatterns =
-		userImages && userImages.remotePatterns
-			? userImages.remotePatterns
-			: [];
+	const userRemotePatterns = userImages.remotePatterns ?? [];
 
 	return {
 		...nextConfig,

--- a/packages/next/src/config/with-snap-wp.ts
+++ b/packages/next/src/config/with-snap-wp.ts
@@ -118,6 +118,7 @@ const withSnapWP = async ( nextConfig?: NextConfig ): Promise< NextConfig > => {
 					protocol: 'https',
 					hostname: homeUrl.hostname,
 				},
+				...( ( nextConfig && nextConfig[ 'remotePatterns' ] ) || [] ),
 			],
 		},
 		webpack: modifyWebpackConfig( snapWPConfigPath ),

--- a/packages/next/src/config/with-snap-wp.ts
+++ b/packages/next/src/config/with-snap-wp.ts
@@ -106,6 +106,12 @@ const withSnapWP = async ( nextConfig?: NextConfig ): Promise< NextConfig > => {
 	setConfig();
 	const homeUrl = new URL( getConfig().homeUrl );
 
+	const userImages = nextConfig && nextConfig.images ? nextConfig.images : {};
+	const userRemotePatterns =
+		nextConfig && nextConfig.images && nextConfig.images.remotePatterns
+			? nextConfig.images.remotePatterns
+			: [];
+
 	return {
 		...nextConfig,
 		images: {
@@ -118,8 +124,10 @@ const withSnapWP = async ( nextConfig?: NextConfig ): Promise< NextConfig > => {
 					protocol: 'https',
 					hostname: homeUrl.hostname,
 				},
-				...( ( nextConfig && nextConfig[ 'remotePatterns' ] ) || [] ),
+				...userRemotePatterns,
 			],
+			// User image config is appended after default config to allow overriding
+			...userImages,
 		},
 		webpack: modifyWebpackConfig( snapWPConfigPath ),
 	};

--- a/packages/next/src/config/with-snap-wp.ts
+++ b/packages/next/src/config/with-snap-wp.ts
@@ -108,8 +108,8 @@ const withSnapWP = async ( nextConfig?: NextConfig ): Promise< NextConfig > => {
 
 	const userImages = nextConfig && nextConfig.images ? nextConfig.images : {};
 	const userRemotePatterns =
-		nextConfig && nextConfig.images && nextConfig.images.remotePatterns
-			? nextConfig.images.remotePatterns
+		userImages && userImages.remotePatterns
+			? userImages.remotePatterns
 			: [];
 
 	return {

--- a/packages/next/src/config/with-snap-wp.ts
+++ b/packages/next/src/config/with-snap-wp.ts
@@ -106,7 +106,7 @@ const withSnapWP = async ( nextConfig?: NextConfig ): Promise< NextConfig > => {
 	setConfig();
 	const homeUrl = new URL( getConfig().homeUrl );
 
-	const userImages = nextConfig && nextConfig.images ? nextConfig.images : {};
+	const userImages = ( nextConfig && nextConfig.images ) ?? {};
 	const userRemotePatterns = userImages.remotePatterns ?? [];
 
 	return {

--- a/packages/next/src/config/with-snap-wp.ts
+++ b/packages/next/src/config/with-snap-wp.ts
@@ -106,12 +106,14 @@ const withSnapWP = async ( nextConfig?: NextConfig ): Promise< NextConfig > => {
 	setConfig();
 	const homeUrl = new URL( getConfig().homeUrl );
 
-	const userImages = ( nextConfig && nextConfig.images ) ?? {};
+	const userImages = nextConfig?.images ?? {};
 	const userRemotePatterns = userImages.remotePatterns ?? [];
 
 	return {
 		...nextConfig,
 		images: {
+			// User image config is appended before default config. Otherwise default remote patterns will be overridden
+			...userImages,
 			remotePatterns: [
 				{
 					protocol: 'http',
@@ -123,8 +125,6 @@ const withSnapWP = async ( nextConfig?: NextConfig ): Promise< NextConfig > => {
 				},
 				...userRemotePatterns,
 			],
-			// User image config is appended after default config to allow overriding
-			...userImages,
 		},
 		webpack: modifyWebpackConfig( snapWPConfigPath ),
 	};


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->
Allows users to add to remote patterns.


## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->


### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->
- Fixes #110 


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->


## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->
N/A

## Additional Info
<!-- Please include any relevant logs, error output, etc -->
N/A

## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [ ] I have updated the project documentation as needed.
-   [x] I have added a changeset for this PR using `npm run changeset`.
