### PR TITLE
dev: Add `@typescript-eslint/no-explicit-any` eslint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -81,6 +81,9 @@ module.exports = {
 			{ children: 'never', props: 'never' },
 		],
 		'react/jsx-boolean-value': 'error',
+
+		// Prevent the use of any in type annotation.
+		'@typescript-eslint/no-explicit-any': 'error',
 	},
 	overrides: [
 		{

--- a/packages/blocks/src/editor-blocks-renderer/index.tsx
+++ b/packages/blocks/src/editor-blocks-renderer/index.tsx
@@ -32,7 +32,7 @@ export default function EditorBlocksRenderer( {
 
 	// eslint-disable-next-line jsdoc/require-jsdoc -- Disable jsdoc for local function.
 	const renderNode = ( node: BlockTreeNode ) => {
-		const props: Record< any, any > = {
+		const props: Record< string | number, unknown > = {
 			key: node.clientId,
 			...node,
 		};

--- a/packages/blocks/src/editor-blocks-renderer/index.tsx
+++ b/packages/blocks/src/editor-blocks-renderer/index.tsx
@@ -32,7 +32,7 @@ export default function EditorBlocksRenderer( {
 
 	// eslint-disable-next-line jsdoc/require-jsdoc -- Disable jsdoc for local function.
 	const renderNode = ( node: BlockTreeNode ) => {
-		const props: Record< string | number, unknown > = {
+		const props: Record< string, unknown > = {
 			key: node.clientId,
 			...node,
 		};

--- a/packages/core/src/logger/index.ts
+++ b/packages/core/src/logger/index.ts
@@ -17,7 +17,10 @@ export enum LOGTYPE {
  * @param type - The type of log message.
  * @param args - The arguments to log.
  */
-const log = ( type: LOGTYPE, ...args: any[] ): void => {
+const log = (
+	type: LOGTYPE,
+	...args: ( string | number | object | boolean )[]
+): void => {
 	if (
 		// eslint-disable-next-line n/no-process-env -- Allow the use of process.env to check the current environment.
 		'production' === process.env.NODE_ENV ||
@@ -62,7 +65,9 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static debug = ( ...args: any[] ): void => log( LOGTYPE.DEBUG, ...args );
+	static debug = (
+		...args: ( string | number | object | boolean )[]
+	): void => log( LOGTYPE.DEBUG, ...args );
 
 	/**
 	 * Logs an info message in the console in dev mode
@@ -73,7 +78,8 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static info = ( ...args: any[] ): void => log( LOGTYPE.INFO, ...args );
+	static info = ( ...args: ( string | number | object | boolean )[] ): void =>
+		log( LOGTYPE.INFO, ...args );
 
 	/**
 	 * Logs a warning in the console in dev mode
@@ -84,7 +90,8 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static warn = ( ...args: any[] ): void => log( LOGTYPE.WARN, ...args );
+	static warn = ( ...args: ( string | number | object | boolean )[] ): void =>
+		log( LOGTYPE.WARN, ...args );
 
 	/**
 	 * Logs an error in the console in dev mode
@@ -95,7 +102,9 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static error = ( ...args: any[] ): void => log( LOGTYPE.ERROR, ...args );
+	static error = (
+		...args: ( string | number | object | boolean )[]
+	): void => log( LOGTYPE.ERROR, ...args );
 
 	/**
 	 * Logs a message in the console in dev mode
@@ -106,7 +115,8 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static log = ( ...args: any[] ): void => log( LOGTYPE.LOG, ...args );
+	static log = ( ...args: ( string | number | object | boolean )[] ): void =>
+		log( LOGTYPE.LOG, ...args );
 }
 
 export { Logger };

--- a/packages/core/src/logger/index.ts
+++ b/packages/core/src/logger/index.ts
@@ -17,10 +17,7 @@ export enum LOGTYPE {
  * @param type - The type of log message.
  * @param args - The arguments to log.
  */
-const log = (
-	type: LOGTYPE,
-	...args: ( string | number | object | boolean )[]
-): void => {
+const log = ( type: LOGTYPE, ...args: unknown[] ): void => {
 	if (
 		// eslint-disable-next-line n/no-process-env -- Allow the use of process.env to check the current environment.
 		'production' === process.env.NODE_ENV ||
@@ -65,9 +62,8 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static debug = (
-		...args: ( string | number | object | boolean )[]
-	): void => log( LOGTYPE.DEBUG, ...args );
+	static debug = ( ...args: unknown[] ): void =>
+		log( LOGTYPE.DEBUG, ...args );
 
 	/**
 	 * Logs an info message in the console in dev mode
@@ -78,8 +74,7 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static info = ( ...args: ( string | number | object | boolean )[] ): void =>
-		log( LOGTYPE.INFO, ...args );
+	static info = ( ...args: unknown[] ): void => log( LOGTYPE.INFO, ...args );
 
 	/**
 	 * Logs a warning in the console in dev mode
@@ -90,8 +85,7 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static warn = ( ...args: ( string | number | object | boolean )[] ): void =>
-		log( LOGTYPE.WARN, ...args );
+	static warn = ( ...args: unknown[] ): void => log( LOGTYPE.WARN, ...args );
 
 	/**
 	 * Logs an error in the console in dev mode
@@ -102,9 +96,8 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static error = (
-		...args: ( string | number | object | boolean )[]
-	): void => log( LOGTYPE.ERROR, ...args );
+	static error = ( ...args: unknown[] ): void =>
+		log( LOGTYPE.ERROR, ...args );
 
 	/**
 	 * Logs a message in the console in dev mode
@@ -115,8 +108,7 @@ class Logger {
 	 *
 	 * @return void
 	 */
-	static log = ( ...args: ( string | number | object | boolean )[] ): void =>
-		log( LOGTYPE.LOG, ...args );
+	static log = ( ...args: unknown[] ): void => log( LOGTYPE.LOG, ...args );
 }
 
 export { Logger };

--- a/packages/next/src/config/with-snap-wp.ts
+++ b/packages/next/src/config/with-snap-wp.ts
@@ -23,6 +23,7 @@ const modifyWebpackConfig = ( snapWPConfigPath: string ) => {
 	 * @see node_modules/next/dist/server/config-shared.js:169
 	 * @return The modified webpack configuration.
 	 */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Using `any` type as the parameter type is `any` in Next.js.
 	return ( config: any ) => {
 		const configPath = `
 			import __snapWPConfig from '${ snapWPConfigPath }';

--- a/packages/next/src/middleware/cors.ts
+++ b/packages/next/src/middleware/cors.ts
@@ -56,8 +56,8 @@ export const corsProxyMiddleware: MiddlewareFactory = (
 					'Content-Security-Policy': "default-src 'self'",
 				},
 			} );
-		} catch ( error ) {
-			Logger.error( 'Proxy error:', error );
+		} catch ( error: unknown ) {
+			Logger.error( 'Proxy error:', error as Error );
 			return NextResponse.json(
 				{ error: 'Internal Server Error' },
 				{ status: 500 }

--- a/packages/next/src/middleware/cors.ts
+++ b/packages/next/src/middleware/cors.ts
@@ -56,12 +56,14 @@ export const corsProxyMiddleware: MiddlewareFactory = (
 					'Content-Security-Policy': "default-src 'self'",
 				},
 			} );
-		} catch ( error: unknown ) {
-			Logger.error( 'Proxy error:', error as Error );
-			return NextResponse.json(
-				{ error: 'Internal Server Error' },
-				{ status: 500 }
-			);
+		} catch ( error ) {
+			if ( error instanceof Error ) {
+				Logger.error( 'Proxy error:', error );
+				return NextResponse.json(
+					{ error: 'Internal Server Error' },
+					{ status: 500 }
+				);
+			}
 		}
 	};
 };

--- a/packages/next/src/middleware/cors.ts
+++ b/packages/next/src/middleware/cors.ts
@@ -57,13 +57,15 @@ export const corsProxyMiddleware: MiddlewareFactory = (
 				},
 			} );
 		} catch ( error ) {
-			if ( error instanceof Error ) {
-				Logger.error( 'Proxy error:', error );
-				return NextResponse.json(
-					{ error: 'Internal Server Error' },
-					{ status: 500 }
-				);
+			if ( ! ( error instanceof Error ) ) {
+				return;
 			}
+
+			Logger.error( 'Proxy error:', error );
+			return NextResponse.json(
+				{ error: 'Internal Server Error' },
+				{ status: 500 }
+			);
 		}
 	};
 };

--- a/packages/types/src/blocks/base.ts
+++ b/packages/types/src/blocks/base.ts
@@ -26,5 +26,6 @@ export type BlockTreeNode< TBlockProps extends BlockData = BlockData > = Omit<
 	'parentClientId'
 > & {
 	children: BlockTreeNode[] | null;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Renderer should be able to render any React Component.
 	renderer: React.ComponentType< any >;
 };

--- a/packages/types/src/blocks/base.ts
+++ b/packages/types/src/blocks/base.ts
@@ -26,6 +26,6 @@ export type BlockTreeNode< TBlockProps extends BlockData = BlockData > = Omit<
 	'parentClientId'
 > & {
 	children: BlockTreeNode[] | null;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Renderer should be able to render any React Component.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- @todo Need to figure out the type of renderer (Type should not be any).
 	renderer: React.ComponentType< any >;
 };

--- a/packages/types/src/blocks/definitions.ts
+++ b/packages/types/src/blocks/definitions.ts
@@ -1,69 +1,8 @@
-import type {
-	CoreAudio,
-	CoreButton,
-	CoreButtons,
-	CoreCode,
-	CoreColumn,
-	CoreColumns,
-	CoreCover,
-	CoreDetails,
-	CoreFile,
-	CoreFreeform,
-	CoreGallery,
-	CoreGroup,
-	CoreHeading,
-	CoreHtml,
-	CoreImage,
-	CoreList,
-	CoreListItem,
-	CoreMediaText,
-	CoreParagraph,
-	CorePattern,
-	CorePostContent,
-	CorePreformatted,
-	CorePullquote,
-	CoreQuote,
-	CoreSeparator,
-	CoreSpacer,
-	CoreTemplatePart,
-	CoreVerse,
-	CoreVideo,
-	Default,
-} from '@/blocks/props';
-
-type componentProps =
-	| CoreAudio
-	| CoreButton
-	| CoreButtons
-	| CoreCode
-	| CoreColumn
-	| CoreColumns
-	| CoreCover
-	| CoreDetails
-	| CoreFile
-	| CoreFreeform
-	| CoreGallery
-	| CoreGroup
-	| CoreHeading
-	| CoreHtml
-	| CoreImage
-	| CoreList
-	| CoreListItem
-	| CoreMediaText
-	| CorePattern
-	| CoreParagraph
-	| CorePostContent
-	| CorePreformatted
-	| CorePullquote
-	| CoreQuote
-	| CoreSeparator
-	| CoreSpacer
-	| CoreTemplatePart
-	| CoreVerse
-	| CoreVideo
-	| Default;
+import React from 'react';
 
 export type BlockDefinitions = {
-	[ key: string ]: componentProps | undefined | null;
-	default: componentProps | undefined | null;
+	/* eslint-disable @typescript-eslint/no-explicit-any -- @todo Need to figure out the type of key & default. */
+	[ key: string ]: React.ComponentType< any > | undefined | null;
+	default: React.ComponentType< any > | undefined | null;
+	/* eslint-enable @typescript-eslint/no-explicit-any -- Re-enable ruleset. */
 };

--- a/packages/types/src/blocks/definitions.ts
+++ b/packages/types/src/blocks/definitions.ts
@@ -1,6 +1,69 @@
-import React from 'react';
+import type {
+	CoreAudio,
+	CoreButton,
+	CoreButtons,
+	CoreCode,
+	CoreColumn,
+	CoreColumns,
+	CoreCover,
+	CoreDetails,
+	CoreFile,
+	CoreFreeform,
+	CoreGallery,
+	CoreGroup,
+	CoreHeading,
+	CoreHtml,
+	CoreImage,
+	CoreList,
+	CoreListItem,
+	CoreMediaText,
+	CoreParagraph,
+	CorePattern,
+	CorePostContent,
+	CorePreformatted,
+	CorePullquote,
+	CoreQuote,
+	CoreSeparator,
+	CoreSpacer,
+	CoreTemplatePart,
+	CoreVerse,
+	CoreVideo,
+	Default,
+} from '@/blocks/props';
+
+type componentProps =
+	| CoreAudio
+	| CoreButton
+	| CoreButtons
+	| CoreCode
+	| CoreColumn
+	| CoreColumns
+	| CoreCover
+	| CoreDetails
+	| CoreFile
+	| CoreFreeform
+	| CoreGallery
+	| CoreGroup
+	| CoreHeading
+	| CoreHtml
+	| CoreImage
+	| CoreList
+	| CoreListItem
+	| CoreMediaText
+	| CorePattern
+	| CoreParagraph
+	| CorePostContent
+	| CorePreformatted
+	| CorePullquote
+	| CoreQuote
+	| CoreSeparator
+	| CoreSpacer
+	| CoreTemplatePart
+	| CoreVerse
+	| CoreVideo
+	| Default;
 
 export type BlockDefinitions = {
-	[ key: string ]: React.ComponentType< any > | undefined | null;
-	default: React.ComponentType< any > | undefined | null;
+	[ key: string ]: componentProps | undefined | null;
+	default: componentProps | undefined | null;
 };

--- a/packages/types/src/blocks/props/core-video.ts
+++ b/packages/types/src/blocks/props/core-video.ts
@@ -17,7 +17,7 @@ export type CoreVideoAttributes = BaseAttributes & {
 	poster?: string;
 	src?: string;
 	style?: string;
-	tracks: Array< any >;
+	tracks: Array< Object | string >;
 	videoPreload: string;
 };
 


### PR DESCRIPTION
## What
- This PR add [@typescript-eslint/no-explicit-any](https://typescript-eslint.io/rules/no-explicit-any/) eslint rule.


### Related Issue(s):
- https://github.com/rtCamp/headless/issues/250

## Testing Instructions
- Run `npm install` && `npm run lint`.

## Additional Info
- As this PR fixes the codebase, we won't be getting any `eslint` errors.

## Checklist

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
