### PR TITLE
chore: Apply and enforce ESLint rules to `bin` and `cli` files

### DIFF
--- a/.changeset/shy-planets-hunt.md
+++ b/.changeset/shy-planets-hunt.md
@@ -1,0 +1,5 @@
+---
+"snapwp": patch
+---
+
+chore: lint fixes

--- a/.changeset/shy-planets-hunt.md
+++ b/.changeset/shy-planets-hunt.md
@@ -2,4 +2,4 @@
 "snapwp": patch
 ---
 
-chore: lint fixes
+chore: Apply and enforce ESLint rules to `bin` and `cli` files

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -108,6 +108,16 @@ module.exports = {
 				'import/default': [ 'off' ],
 			},
 		},
+		// Rules for bin and cli files.
+		{
+			files: [ 'bin/**/*.js', 'bin/**/*.mjs', 'packages/cli/src/*.cjs' ],
+			rules: {
+				// Enable the use of console log.
+				'no-console': 'off',
+				// Enable the use of process-env.
+				'n/no-process-env': 'off',
+			},
+		},
 		// Disable n/no-process-env for `codegen.ts` file.
 		{
 			files: [ '**/codegen.ts', '**/*.test.*', '**/jest.setup.js' ],

--- a/packages/cli/src/snapwp.cjs
+++ b/packages/cli/src/snapwp.cjs
@@ -3,7 +3,7 @@ const registryURL = 'http://localhost:4873';
 const npmrcContent = `@snapwp:registry=${ registryURL }`;
 
 // Scaffold a new directory with the SnapWP build and the .env file.
-const { execSync, spawn } = require( 'child_process' );
+const { spawn } = require( 'child_process' );
 const fs = require( 'fs/promises' );
 const path = require( 'path' );
 const readline = require( 'readline' );
@@ -13,26 +13,12 @@ program.option( '--proxy', 'Use proxy registry.' ).parse();
 
 const options = program.opts();
 
-// Utility function to execute shell commands
 /**
+ * Prompts the user for input.
  *
- * @param command
- * @param options
- */
-const exec = ( command, options = {} ) => {
-	console.log( `Executing: ${ command }` );
-	execSync( command, {
-		stdio: 'inherit',
-		shell: true,
-		env: { ...process.env, PATH: process.env.PATH },
-		...options,
-	} );
-};
-
-// Prompt the user for input
-/**
+ * @param {string} query Prompt query.
  *
- * @param query
+ * @return {Promise<string>} User input.
  */
 const prompt = ( query ) => {
 	const rl = readline.createInterface( {
@@ -69,7 +55,7 @@ const openEditor = ( filePath ) => {
 				stdio: 'inherit',
 			} );
 
-			child.on( 'exit', function ( e, code ) {
+			child.on( 'exit', function () {
 				resolve( {
 					success: true,
 					message: `File created at "${ path.resolve( filePath ) }"`,
@@ -156,9 +142,9 @@ const openEditor = ( filePath ) => {
 			// Throw error if .env file still does not exist or if exists, its empty.
 			try {
 				await fs.access( envPath );
-			} catch ( error ) {
+			} catch ( err ) {
 				// Throw error if .env file still does not exist.
-				if ( 'ENOENT' === error.code ) {
+				if ( 'ENOENT' === err.code ) {
 					console.error(
 						`".env" still not found at "${ envPath }". Please create an ".env" and try again.`
 					);
@@ -166,7 +152,7 @@ const openEditor = ( filePath ) => {
 				}
 
 				// Exit if any other unknown error occurred.
-				console.error( 'Error:', error );
+				console.error( 'Error:', err );
 				process.exit( 1 );
 			}
 		}


### PR DESCRIPTION
## What
- This PR 
    - Enables use of console and process-env in CLI and bin files + fixes their eslint errors. 
    - Removes unused `exec` function from CLI package.

### Related Issue(s):
- https://github.com/rtCamp/headless/issues/250

## Testing Instructions
- Run `npm install` && `npm run lint`.

## Additional Info
- As this PR fixes the codebase, we won't be getting any `eslint` errors.


## Checklist

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
