### PR TITLE
fix : Support area attribute as a fallback for `templatePartTagName` in `CoreTemplatePart`.

### DIFF
--- a/packages/blocks/src/blocks/core-template-part.tsx
+++ b/packages/blocks/src/blocks/core-template-part.tsx
@@ -20,13 +20,17 @@ const CoreTemplatePart: CoreTemplatePartType = ( {
 	children,
 	attributes,
 }: CoreTemplatePartProps ) => {
-	const { templatePartTagName } = attributes || {};
-	/**
-	 * @todo add support for area_tag.
-	 * @see https://github.com/WordPress/gutenberg/blob/4775e7052b9e2ed7df46429e6e738de3faf2fb18/packages/block-library/src/template-part/index.php#L165
-	 */
-	const TagName = ( templatePartTagName ||
-		'div' ) as keyof JSX.IntrinsicElements;
+	const { templatePartTagName, area } = attributes || {};
+
+	let htmlTag = 'div';
+
+	if ( templatePartTagName ) {
+		htmlTag = templatePartTagName;
+	} else if ( typeof area === 'string' && area.trim() !== '' ) {
+		htmlTag = area;
+	}
+
+	const TagName = htmlTag as keyof JSX.IntrinsicElements;
 
 	/**
 	 * @todo replace with cssClassName once it's supported.

--- a/packages/query/src/fragments/core-template-part.graphql
+++ b/packages/query/src/fragments/core-template-part.graphql
@@ -1,6 +1,7 @@
 fragment CoreTemplatePartFrag on CoreTemplatePart {
 	renderedHtml
 	attributes {
+		area
 		className
 		slug
 		templatePartTagName: tagName

--- a/packages/types/src/blocks/props/core-template-part.ts
+++ b/packages/types/src/blocks/props/core-template-part.ts
@@ -3,6 +3,7 @@ import type { BaseAttributes, BaseProps } from '../base';
 
 export type CoreTemplatePartAttributes = BaseAttributes & {
 	templatePartTagName?: string;
+	area?: string;
 };
 
 export type CoreTemplatePartProps = PropsWithChildren<


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->
- This PR updates the `CoreTemplatePart` component to use the `area` attribute as a fallback when `templatePartTagName` is not provided.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
- Ensures that the `area` attribute is available in the response from the GraphQL query.
- Allows the `CoreTemplatePart` component to use area as a fallback for `templatePartTagName`.
- Updates type definitions to include area, improving type safety and consistency.

### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->
- Fixes [Task: Add support for CoreTemplate block area_tag. #407](https://github.com/rtCamp/headless/issues/407)

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->

- Modified the logic to use area as a fallback for `templatePartTagName`.
- Ensured type safety by checking if area is a valid string before using it.
- Added area to the `CoreTemplatePartFrag` fragment.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
NA


## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->
NA

## Additional Info
<!-- Please include any relevant logs, error output, etc -->
NA


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [ ] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [ ] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
