### PR TITLE
ci: prettier format on changesets pr

### DIFF
--- a/.github/workflows/release_packages.yml
+++ b/.github/workflows/release_packages.yml
@@ -37,6 +37,17 @@ jobs:
                   commit: 'chore: version bump'
                   title: 'chore: Release packages 🏷️'
 
+            - name: Fix prettier on changesets pull request
+              if: steps.changesets.outputs.hasChangesets == 'true'
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  gh pr checkout ${{ steps.changesets.outputs.pullRequestNumber }}
+                  npm run format
+                  # If there are changes, commit, otherwise exit successfully
+                  git diff --exit-code || git commit -am "chore: format changesets" && git push orign HEAD
+
             - name: Check what packages to publish
               id: check_publish
               if: steps.changesets.outputs.hasChangesets == 'false'


### PR DESCRIPTION
## What
Runs a prettier format check on changesets PR to reformat anything which doesn't align with `format:check` using the `format` script.

## Why
Sometimes the changesets pull request is not properly formatted. This is to fix that.

Refer #121 for more details.


### Related Issue(s):
- Resolves #121

## How
1. Changeset pull request creation logic runs as is
2. We run `npm run format` on the pull request itself
3. If any file is changed, we commit, and then push to PR.
4. If there are no files which changed, everything is properly formatted.


## Additional Info
This fix relies on relation between `format` and `format:check` scripts. If `format` is not properly validated by `format:check`, this fix may fail.

## Checklist
-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [ ] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [ ] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
