### PR TITLE
fix: avoid unnecessary `favicon.ico` requests when unset

### DIFF
--- a/.changeset/tall-pens-rule.md
+++ b/.changeset/tall-pens-rule.md
@@ -1,0 +1,5 @@
+---
+"@snapwp/next": minor
+---
+
+fix: favicon.ico request making page request to WP server

--- a/.changeset/tall-pens-rule.md
+++ b/.changeset/tall-pens-rule.md
@@ -1,5 +1,5 @@
 ---
-"@snapwp/next": minor
+"@snapwp/next": patch
 ---
 
-fix: favicon.ico request making page request to WP server
+fix: avoid unnecessary `favicon.ico` requests when unset.

--- a/packages/next/src/middleware/proxies.ts
+++ b/packages/next/src/middleware/proxies.ts
@@ -22,6 +22,10 @@ export const proxies: MiddlewareFactory = ( next: NextMiddleware ) => {
 	return async ( request: NextRequest, _next: NextFetchEvent ) => {
 		const nextPath = request.nextUrl.pathname;
 
+		if ( '/favicon.ico' === nextPath ) {
+			return NextResponse.json( {}, { status: 404 } );
+		}
+
 		const { wpHomeUrl, uploadsDirectory, restUrlPrefix } = getConfig();
 
 		// Proxy for WordPress uploads.
@@ -56,10 +60,6 @@ export const proxies: MiddlewareFactory = ( next: NextMiddleware ) => {
 			return NextResponse.redirect(
 				new URL( '/wp-admin/admin-ajax.php', wpHomeUrl )
 			);
-		}
-
-		if ( '/favicon.ico' === nextPath ) {
-			return NextResponse.json( {}, { status: 404 } );
 		}
 
 		return next( request, _next );

--- a/packages/next/src/middleware/proxies.ts
+++ b/packages/next/src/middleware/proxies.ts
@@ -58,7 +58,7 @@ export const proxies: MiddlewareFactory = ( next: NextMiddleware ) => {
 			);
 		}
 
-		if ( 'favicon.ico' === nextPath ) {
+		if ( '/favicon.ico' === nextPath ) {
 			return NextResponse.json( {}, { status: 404 } );
 		}
 

--- a/packages/next/src/middleware/proxies.ts
+++ b/packages/next/src/middleware/proxies.ts
@@ -58,6 +58,10 @@ export const proxies: MiddlewareFactory = ( next: NextMiddleware ) => {
 			);
 		}
 
+		if ( 'favicon.ico' === nextPath ) {
+			return NextResponse.json( {}, { status: 404 } );
+		}
+
 		return next( request, _next );
 	};
 };

--- a/packages/next/src/root-layout/icons-metadata.ts
+++ b/packages/next/src/root-layout/icons-metadata.ts
@@ -40,19 +40,15 @@ export const getIcons = async (): Promise< IconMetaData > => {
 	const settings: GeneralSettingsProps | undefined =
 		await QueryEngine.getGeneralSettings();
 
-	if ( ! settings ) {
-		return {
-			faviconIcons: [],
-			appleIcons: undefined,
-			msApplicationTileIcon: undefined,
-		};
-	}
-
 	let fallbackIcons: IconMetaData = {
-		faviconIcons: [],
+		faviconIcons: [ { url: '#', sizes: '' } ],
 		appleIcons: undefined,
 		msApplicationTileIcon: undefined,
 	};
+
+	if ( ! settings ) {
+		return fallbackIcons;
+	}
 
 	// Creating fallback icons if siteIcon is present but mediaDetails is not.
 	if ( settings.generalSettings.siteIcon.mediaItemUrl ) {


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->
- This PR will fix the new GraphQL request sent for favicon.ico

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
- When icon tag is not available in head tag browser tries to fetch it from /favicon.ico path. This request is getting to the NextJS Server and it is considering this request to a page request and making a GQL request to fetch favicon.ico request.


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
- Passing # as icon when Icon is not available

## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [x] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [x] I have added a changeset for this PR using `npm run changeset`.
