### PR TITLE
fix: use `SITE_URL` for GraphQL endpoint instead of `HOME_URL`

### DIFF
--- a/.changeset/cold-cows-joke.md
+++ b/.changeset/cold-cows-joke.md
@@ -3,4 +3,4 @@
 "@snapwp/core": patch
 ---
 
-feat: use SITE_URL for GraphQL endpoint instead of HOME_URL
+fix: use NEXT_PUBLIC_SITE_URL for GraphQL endpoint when available.

--- a/.changeset/cold-cows-joke.md
+++ b/.changeset/cold-cows-joke.md
@@ -1,0 +1,6 @@
+---
+"@snapwp/query": patch
+"@snapwp/core": patch
+---
+
+feat: use SITE_URL for GraphQL endpoint instead of HOME_URL

--- a/examples/nextjs/starter/codegen.ts
+++ b/examples/nextjs/starter/codegen.ts
@@ -14,7 +14,8 @@ const config: CodegenConfig = {
 	schema: process.env.GRAPHQL_SCHEMA_FILE ?? [
 		{
 			[ generateGraphqlUrl(
-				process.env.NEXT_PUBLIC_WP_HOME_URL,
+				process.env.NEXT_PUBLIC_WP_SITE_URL ||
+					process.env.NEXT_PUBLIC_WP_HOME_URL,
 				process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT
 			) ]: {
 				headers: {

--- a/examples/nextjs/starter/codegen.ts
+++ b/examples/nextjs/starter/codegen.ts
@@ -7,17 +7,20 @@ import 'dotenv/config';
 const GRAPHQL_GLOB = './src/**/*.graphql';
 const graphqlFiles = globSync( GRAPHQL_GLOB );
 
+// This is necessary because we don't have access to the Config Manager.
+const graphqlUrl = generateGraphqlUrl(
+	// If there's no explicit SITE_URL, it's the same as the HOME_URL.
+	process.env.NEXT_PUBLIC_WP_SITE_URL || process.env.NEXT_PUBLIC_WP_HOME_URL,
+	process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT
+);
+
 const config: CodegenConfig = {
 	...( graphqlFiles.length > 0 && { documents: GRAPHQL_GLOB } ),
 	...baseConfig,
 	// Use the schema file if it's set by CI.
 	schema: process.env.GRAPHQL_SCHEMA_FILE ?? [
 		{
-			[ generateGraphqlUrl(
-				process.env.NEXT_PUBLIC_WP_SITE_URL ||
-					process.env.NEXT_PUBLIC_WP_HOME_URL,
-				process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT
-			) ]: {
+			[ graphqlUrl ]: {
 				headers: {
 					Authorization: `${ process.env.INTROSPECTION_TOKEN }`,
 				},

--- a/packages/core/src/config/snapwp-config-manager.ts
+++ b/packages/core/src/config/snapwp-config-manager.ts
@@ -374,7 +374,8 @@ class SnapWPConfigManager {
 	 */
 	static getGraphqlUrl(): string {
 		return generateGraphqlUrl(
-			SnapWPConfigManager.getConfig().wpHomeUrl,
+			SnapWPConfigManager.getConfig().wpSiteUrl ||
+				SnapWPConfigManager.getConfig().wpHomeUrl,
 			SnapWPConfigManager.getConfig().graphqlEndpoint
 		);
 	}

--- a/packages/core/src/config/snapwp-config-manager.ts
+++ b/packages/core/src/config/snapwp-config-manager.ts
@@ -374,8 +374,7 @@ class SnapWPConfigManager {
 	 */
 	static getGraphqlUrl(): string {
 		return generateGraphqlUrl(
-			SnapWPConfigManager.getConfig().wpSiteUrl ||
-				SnapWPConfigManager.getConfig().wpHomeUrl,
+			SnapWPConfigManager.getConfig().wpSiteUrl,
 			SnapWPConfigManager.getConfig().graphqlEndpoint
 		);
 	}

--- a/packages/query/codegen.ts
+++ b/packages/query/codegen.ts
@@ -13,7 +13,8 @@ const config: CodegenConfig = {
 	schema: process.env.GRAPHQL_SCHEMA_FILE ?? [
 		{
 			[ generateGraphqlUrl(
-				process.env.NEXT_PUBLIC_WP_HOME_URL,
+				process.env.NEXT_PUBLIC_WP_SITE_URL ||
+					process.env.NEXT_PUBLIC_WP_HOME_URL,
 				process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT
 			) ]: {
 				headers: {

--- a/packages/query/codegen.ts
+++ b/packages/query/codegen.ts
@@ -6,17 +6,20 @@ import type { CodegenConfig } from '@graphql-codegen/cli';
 
 dotenv.config( { path: '../../.env' } );
 
+// This is necessary because we don't have access to the config manager.
+const graphqlUrl = generateGraphqlUrl(
+	// If there's no explicit SITE_URL, it's the same as the HOME_URL.
+	process.env.NEXT_PUBLIC_WP_SITE_URL || process.env.NEXT_PUBLIC_WP_HOME_URL,
+	process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT
+);
+
 const config: CodegenConfig = {
 	...baseConfigs,
 	documents: './src/**/*.graphql',
 	// Use the schema file if it's set by CI.
 	schema: process.env.GRAPHQL_SCHEMA_FILE ?? [
 		{
-			[ generateGraphqlUrl(
-				process.env.NEXT_PUBLIC_WP_SITE_URL ||
-					process.env.NEXT_PUBLIC_WP_HOME_URL,
-				process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT
-			) ]: {
+			[ graphqlUrl ]: {
 				headers: {
 					Authorization: `${ process.env.INTROSPECTION_TOKEN }`,
 				},


### PR DESCRIPTION
## What
This PR uses `SITE_URL` for GraphQL endpoint instead of `HOME_URL`

## Why
In a bedrock setup, the graphql server is at host:port/wp/graphql and host:port/wp is the WP SITE_URL whereas often the HOME_URL will be just host:port

### Related Issue(s):
https://github.com/rtCamp/snapwp/issues/149

## How
Updated instances of generateGraphQLUrl() - passed SITE_URL instead of HOME_URL, per [WPGraphQL’s logic](https://github.com/wp-graphql/wp-graphql/blob/200dcef15f98fecc0af3d3852bdb9792488dfa8d/access-functions.php#L874).

## Testing Instructions


## Screenshots


## Additional Info


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [ ] My code has detailed inline documentation.
-   [x] I have added unit tests to verify the code works as intended.
-   [ ] I have updated the project documentation as needed.
-   [x] I have added a changeset for this PR using `npm run changeset`.
