### PR TITLE
fix: override `eslint-react-hooks-plugin`

### DIFF
--- a/.changeset/orange-worms-shout.md
+++ b/.changeset/orange-worms-shout.md
@@ -2,4 +2,4 @@
 "snapwp": patch
 ---
 
-fix: Override eslint-react-hooks-plugin
+fix: Override eslint-react-hooks-plugin to prevent conflicts between `@wordpress/eslint-plugin` and `eslint-plugin-next`.

--- a/.changeset/orange-worms-shout.md
+++ b/.changeset/orange-worms-shout.md
@@ -1,0 +1,5 @@
+---
+"snapwp": patch
+---
+
+fix: Override eslint-react-hooks-plugin

--- a/examples/nextjs/starter/package.json
+++ b/examples/nextjs/starter/package.json
@@ -50,5 +50,8 @@
 		"jest-environment-jsdom": "^29.7.0",
 		"prettier": "npm:wp-prettier@^3.0.3",
 		"typescript": ">=4.3.5"
+	},
+	"overrides": {
+		"eslint-plugin-react-hooks": "^5.2.0"
 	}
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
This PR resolves a conflict caused by eslint-plugin-react-hooks being pulled in by both:

eslint-config-next
@wordpress/eslint-plugin

ESLint does not allow multiple versions of the same plugin in a single config, resulting in a plugin conflict error when running eslint.


## Why
By adding the overrides field in the test app, we force a single version (^5.2.0) of eslint-plugin-react-hooks to be used throughout the dependency tree


### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
Added a package-level overrides entry in the test app's package.json:

```json
"overrides": {
  "eslint-plugin-react-hooks": "^5.2.0"
}
```

## Testing Instructions
1. Run `snapwp`
2. Scaffold the test app outside the snapwp directory, e.g. `../snapwp-app`
3. Run `npm run lint` in `snapwp-app`

## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->


## Additional Info
<!-- Please include any relevant logs, error output, etc -->


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [ ] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [ ] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
