### PR TITLE
feat : Backfill `parseGeneralSettings` test in `@snapwp/query` package.

### DIFF
--- a/.changeset/strong-hornets-strive.md
+++ b/.changeset/strong-hornets-strive.md
@@ -1,0 +1,5 @@
+---
+"@snapwp/query": minor
+---
+
+feat: backfill test for `parseGeneralSettings` utils function.

--- a/packages/query/src/utils/tests/parse-general-settings.test.ts
+++ b/packages/query/src/utils/tests/parse-general-settings.test.ts
@@ -1,0 +1,184 @@
+import { Logger } from '@snapwp/core';
+import { parseGeneralSettings } from '../parse-general-settings';
+
+import type { ApolloQueryResult } from '@apollo/client';
+import type { GetGeneralSettingsQuery } from '@graphqlTypes/graphql';
+
+jest.mock( '@snapwp/core', () => ( {
+	...jest.requireActual( '@snapwp/core' ),
+	Logger: {
+		error: jest.fn(),
+	},
+} ) );
+
+describe( 'parseGeneralSettings', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should parse valid query data correctly', () => {
+		const queryData: ApolloQueryResult< GetGeneralSettingsQuery > = {
+			data: {
+				generalSettings: {
+					siteIcon: {
+						mediaItemUrl: 'https://snapwp.local/icon.png',
+						mediaDetails: {
+							sizes: [
+								{
+									sourceUrl:
+										'https://snapwp.local/icon-100x100.png',
+									height: '100',
+									width: '100',
+								},
+								{
+									sourceUrl:
+										'https://snapwp.local/icon-200x200.png',
+									height: '200',
+									width: '200',
+								},
+							],
+						},
+					},
+				},
+			},
+			errors: [],
+			loading: false,
+			networkStatus: 7,
+		};
+
+		const result = parseGeneralSettings( queryData );
+
+		expect( result ).toEqual( {
+			generalSettings: {
+				siteIcon: {
+					mediaItemUrl: 'https://snapwp.local/icon.png',
+					mediaDetails: {
+						sizes: [
+							{
+								sourceUrl:
+									'https://snapwp.local/icon-100x100.png',
+								height: '100',
+								width: '100',
+							},
+							{
+								sourceUrl:
+									'https://snapwp.local/icon-200x200.png',
+								height: '200',
+								width: '200',
+							},
+						],
+					},
+				},
+			},
+		} );
+	} );
+
+	it( 'should return undefined if siteIcon is missing', () => {
+		const queryData: ApolloQueryResult< GetGeneralSettingsQuery > = {
+			data: {
+				generalSettings: {},
+			},
+			errors: [],
+			loading: false,
+			networkStatus: 7,
+		};
+
+		const result = parseGeneralSettings( queryData );
+
+		expect( result ).toBeUndefined();
+	} );
+
+	it( 'should return undefined if sizes are incomplete or invalid', () => {
+		const queryData: ApolloQueryResult< GetGeneralSettingsQuery > = {
+			data: {
+				generalSettings: {
+					siteIcon: {
+						mediaItemUrl: 'https://snapwp.local/icon.png',
+						mediaDetails: {
+							sizes: [
+								{
+									sourceUrl:
+										'https://snapwp.local/icon-100x100.png',
+									height: '100',
+									width: '100',
+								},
+								{ sourceUrl: '', height: '', width: '' },
+							],
+						},
+					},
+				},
+			},
+			errors: [],
+			loading: false,
+			networkStatus: 7,
+		};
+
+		const result = parseGeneralSettings( queryData );
+
+		expect( result ).toEqual( {
+			generalSettings: {
+				siteIcon: {
+					mediaItemUrl: 'https://snapwp.local/icon.png',
+					mediaDetails: {
+						sizes: [
+							{
+								sourceUrl:
+									'https://snapwp.local/icon-100x100.png',
+								height: '100',
+								width: '100',
+							},
+						],
+					},
+				},
+			},
+		} );
+	} );
+
+	it( 'should log errors and still return valid data when there are query errors', () => {
+		const queryData: ApolloQueryResult< GetGeneralSettingsQuery > = {
+			data: {
+				generalSettings: {
+					siteIcon: {
+						mediaItemUrl: 'https://snapwp.local/icon.png',
+						mediaDetails: {
+							sizes: [
+								{
+									sourceUrl:
+										'https://snapwp.local/icon-100x100.png',
+									height: '100',
+									width: '100',
+								},
+							],
+						},
+					},
+				},
+			},
+			errors: [ { message: 'Sample error message' } ],
+			loading: false,
+			networkStatus: 7,
+		};
+
+		const result = parseGeneralSettings( queryData );
+
+		expect( Logger.error ).toHaveBeenCalledWith(
+			'Error fetching global styles: [object Object]'
+		);
+		expect( result ).toEqual( {
+			generalSettings: {
+				siteIcon: {
+					mediaItemUrl: 'https://snapwp.local/icon.png',
+					mediaDetails: {
+						sizes: [
+							{
+								sourceUrl:
+									'https://snapwp.local/icon-100x100.png',
+								height: '100',
+								width: '100',
+							},
+						],
+					},
+				},
+			},
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->
- Backfills the `parseGeneralSettings` function to parse site icon and media details from query data, handling missing or invalid data gracefully. 
- Adds tests for different scenarios.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
- Ensures that the general settings query data is parsed correctly and handles errors, providing better data integrity.

### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->
- Part of [https://github.com/rtCamp/headless/issues/279](https://github.com/rtCamp/headless/issues/279)

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
- Parses siteIcon and mediaDetails, returning valid data or undefined for missing fields.
- Logs errors when query data contains issues.
- Tests added for valid data, missing siteIcon, invalid sizes, and error handling.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Run `npm run test:unit`.

## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->
<img width="524" alt="Screenshot 2025-04-21 at 5 06 08 PM" src="https://github.com/user-attachments/assets/e792fc1e-55cf-48c9-895b-b77ecc51eb93" />

## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [x] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [x] I have added a changeset for this PR using `npm run changeset`.
