### PR TITLE
fix(ci): use locally built version of snapwp starter template

### DIFF
--- a/.github/workflows/pull_request_examples.yml
+++ b/.github/workflows/pull_request_examples.yml
@@ -118,6 +118,7 @@ jobs:
               run: |
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
+                  # Had to resort to a local install because npm link didn't want to work properly. Refer #165
                   npm i '${{ github.workspace }}/packages/cli' --no-save
                   npx snapwp --proxy <<< '.'
                   npm i

--- a/.github/workflows/pull_request_examples.yml
+++ b/.github/workflows/pull_request_examples.yml
@@ -100,7 +100,6 @@ jobs:
                   npm ci --workspaces --include-workspace-root
                   npm run --if-present local-registry:start
                   npm run --if-present build
-                  npm link snapwp
 
                   # Ensure Verdaccio has the right permissions for CI
                   touch .verdaccio/conf/htpasswd
@@ -120,7 +119,7 @@ jobs:
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
                   npm i '${{ github.workspace }}/packages/cli' --no-save
-                  npx snapwp <<< '.'
+                  npx snapwp --proxy <<< '.'
                   npm i
 
             - name: Run ESLint
@@ -172,7 +171,6 @@ jobs:
                   npm ci --workspaces --include-workspace-root
                   npm run --if-present local-registry:start
                   npm run --if-present build
-                  npm link snapwp
 
                   # Ensure Verdaccio has the right permissions for CI
                   touch .verdaccio/conf/htpasswd
@@ -191,7 +189,8 @@ jobs:
               run: |
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
-                  snapwp --proxy <<< '.'
+                  npm i '${{ github.workspace }}/packages/cli' --no-save
+                  npx snapwp --proxy <<< '.'
                   npm i
 
             - name: Run Codegen
@@ -290,7 +289,6 @@ jobs:
                   npm ci --workspaces --include-workspace-root
                   npm run --if-present local-registry:start
                   npm run --if-present build
-                  npm link snapwp
 
                   # Ensure Verdaccio has the right permissions for CI
                   touch .verdaccio/conf/htpasswd
@@ -309,7 +307,8 @@ jobs:
               run: |
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
-                  snapwp --proxy <<< '.'
+                  npm i '${{ github.workspace }}/packages/cli' --no-save
+                  npx snapwp --proxy <<< '.'
                   npm i
 
             - name: Build assets
@@ -362,7 +361,6 @@ jobs:
                   npm ci --workspaces --include-workspace-root
                   npm run --if-present local-registry:start
                   npm run --if-present build
-                  npm link snapwp
 
                   # Ensure Verdaccio has the right permissions for CI
                   touch .verdaccio/conf/htpasswd
@@ -381,7 +379,8 @@ jobs:
               run: |
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
-                  snapwp --proxy <<< '.'
+                  npm i '${{ github.workspace }}/packages/cli' --no-save
+                  npx snapwp --proxy <<< '.'
                   npm i
 
             - name: Run unit tests
@@ -433,8 +432,7 @@ jobs:
                   npm ci --workspaces --include-workspace-root
                   npm run --if-present local-registry:start
                   npm run --if-present build
-                  npm link snapwp
-
+                
                   # Ensure Verdaccio has the right permissions for CI
                   touch .verdaccio/conf/htpasswd
                   sudo chmod 666 .verdaccio/conf/htpasswd  # Required so verdaccio container can add our user
@@ -452,7 +450,8 @@ jobs:
               run: |
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
-                  snapwp --proxy <<< '.'
+                  npm i '${{ github.workspace }}/packages/cli' --no-save
+                  npx snapwp --proxy <<< '.'
                   npm i
 
             - name: Run npm audit
@@ -504,7 +503,6 @@ jobs:
                   npm ci --workspaces --include-workspace-root
                   npm run --if-present local-registry:start
                   npm run --if-present build
-                  npm link snapwp
 
                   # Ensure Verdaccio has the right permissions for CI
                   touch .verdaccio/conf/htpasswd
@@ -523,7 +521,8 @@ jobs:
               run: |
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
-                  snapwp --proxy <<< '.'
+                  npm i '${{ github.workspace }}/packages/cli' --no-save
+                  npx snapwp --proxy <<< '.'
                   npm i
 
             - name: Run Prettier

--- a/.github/workflows/pull_request_examples.yml
+++ b/.github/workflows/pull_request_examples.yml
@@ -118,7 +118,9 @@ jobs:
               run: |
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
-                  # Had to resort to a local install because npm link didn't want to work properly. Refer #165
+
+                  # We use a local install because npm link is flaky in CI.
+                  # @see https://github.com/rtCamp/snapwp/pull/
                   npm i '${{ github.workspace }}/packages/cli' --no-save
                   npx snapwp --proxy <<< '.'
                   npm i
@@ -190,6 +192,9 @@ jobs:
               run: |
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
+
+                  # We use a local install because npm link is flaky in CI.
+                  # @see https://github.com/rtCamp/snapwp/pull/
                   npm i '${{ github.workspace }}/packages/cli' --no-save
                   npx snapwp --proxy <<< '.'
                   npm i
@@ -308,6 +313,9 @@ jobs:
               run: |
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
+
+                  # We use a local install because npm link is flaky in CI.
+                  # @see https://github.com/rtCamp/snapwp/pull/
                   npm i '${{ github.workspace }}/packages/cli' --no-save
                   npx snapwp --proxy <<< '.'
                   npm i
@@ -380,6 +388,9 @@ jobs:
               run: |
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
+
+                  # We use a local install because npm link is flaky in CI.
+                  # @see https://github.com/rtCamp/snapwp/pull/
                   npm i '${{ github.workspace }}/packages/cli' --no-save
                   npx snapwp --proxy <<< '.'
                   npm i
@@ -433,7 +444,7 @@ jobs:
                   npm ci --workspaces --include-workspace-root
                   npm run --if-present local-registry:start
                   npm run --if-present build
-                
+
                   # Ensure Verdaccio has the right permissions for CI
                   touch .verdaccio/conf/htpasswd
                   sudo chmod 666 .verdaccio/conf/htpasswd  # Required so verdaccio container can add our user
@@ -451,6 +462,9 @@ jobs:
               run: |
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
+
+                  # We use a local install because npm link is flaky in CI.
+                  # @see https://github.com/rtCamp/snapwp/pull/
                   npm i '${{ github.workspace }}/packages/cli' --no-save
                   npx snapwp --proxy <<< '.'
                   npm i
@@ -522,6 +536,9 @@ jobs:
               run: |
                   cp '${{ github.workspace }}/examples/${{ matrix.example }}/.env.example' .env
                   sed -i 's|NEXT_PUBLIC_WP_HOME_URL=.*|NEXT_PUBLIC_WP_HOME_URL=http://localhost|' .env
+
+                  # We use a local install because npm link is flaky in CI.
+                  # @see https://github.com/rtCamp/snapwp/pull/
                   npm i '${{ github.workspace }}/packages/cli' --no-save
                   npx snapwp --proxy <<< '.'
                   npm i


### PR DESCRIPTION
## What
Change the use of `npm link` in ci with a temporary local install.


## Why
CLI version used after `npm link` is still the one from npm registry, and not the one built locally.

- https://github.com/rtCamp/headless/issues/460

## How
Replaced use of `npm link` in ci with a local install for locally built CLI version and then use it via `npx` to avoid using global version of SnapWP CLI. During internal testing, this turned out to be less error prone, whereas for `npm link`, it would sometimes use local version and sometimes one from npm registry, and show different errors randomly.


## Checklist
-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [ ] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [ ] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
