### PR TITLE
Update aria label

### DIFF
--- a/.changeset/synced-pattern-support.md
+++ b/.changeset/synced-pattern-support.md
@@ -1,0 +1,14 @@
+
+
+---
+"@snapwp/blocks": minor
+"@snapwp/types": minor
+"@snapwp/core": minor
+---
+
+feat: Add support for synced patterns
+
+- Add CoreSyncedPattern component for rendering synced patterns
+- Add comprehensive unit tests for the component
+- Update documentation with examples and best practices
+- Fix issue with pattern flattening in WPGraphQL Content Blocks 

--- a/docs/overloading-wp-behavior.md
+++ b/docs/overloading-wp-behavior.md
@@ -306,3 +306,92 @@ export default function Page() {
 
 -   **Local Styles**: Use CSS Modules (as shown with `styles.module.css`) or any other CSS-in-JS solution for component-specific styling.
 -   **Global and Theme Styles**: Classes like `wp-block-heading`, `has-text-align-center`, and `has-x-large-font-size` (likely from your WordPress `theme.json` and/or global CSS) are automatically available.
+
+## Overloading Synced Patterns
+
+SnapWP allows you to customize **Synced Patterns** by mapping them to custom React components. This is useful for modifying the structure, design, or behavior of reusable block patterns while keeping WordPress as the content source.
+
+> [!TIP]
+> Synced Patterns are reusable block patterns in WordPress that stay in sync across all instances. When you edit a synced pattern, all instances of that pattern are updated.
+
+### 1. Creating a Custom Component
+
+Create a new React component to modify the rendering of a specific Synced Pattern:
+
+```tsx
+import React from 'react';
+import { BlockData, cn, getClassNamesFromString } from '@snapwp/core';
+
+export default function MyCustomSyncedPattern({
+	renderedHtml,
+	attributes,
+	children,
+}: BlockData) {
+	const safeAttributes = attributes || {}; // Ensure attributes are not undefined.
+	const { style } = safeAttributes;
+
+	const classNamesFromString = renderedHtml
+		? getClassNamesFromString(renderedHtml)
+		: '';
+	const classNames = cn(classNamesFromString);
+
+	return (
+		<div className={classNames} style={style}>
+			{/* Your custom rendering logic here */}
+			{children}
+		</div>
+	);
+}
+```
+
+### 2. Registering the Custom Component
+
+You can register your custom component either globally or per-route:
+
+#### Global Registration
+
+Add your custom component to the `blockDefinitions` in your `snapwp.config.ts`:
+
+```ts
+import { defineConfig } from '@snapwp/config';
+import MyCustomSyncedPattern from './components/MyCustomSyncedPattern';
+
+export default defineConfig({
+	blockDefinitions: {
+		CoreSyncedPattern: MyCustomSyncedPattern,
+	},
+});
+```
+
+#### Per-Route Registration
+
+Override the component for specific routes:
+
+```tsx
+import { EditorBlocksRenderer } from '@snapwp/blocks';
+import MyCustomSyncedPattern from './components/MyCustomSyncedPattern';
+
+const pageBlockDefinitions = {
+	CoreSyncedPattern: MyCustomSyncedPattern,
+};
+
+export default function Page() {
+	return (
+		<TemplateRenderer>
+			{(editorBlocks) => (
+				<EditorBlocksRenderer
+					editorBlocks={editorBlocks}
+					blockDefinitions={pageBlockDefinitions}
+				/>
+			)}
+		</TemplateRenderer>
+	);
+}
+```
+
+This allows you to apply the override only on specific routes while using the default block rendering elsewhere.
+
+Now, whenever a `core/synced-pattern` block is encountered, your `MyCustomSyncedPattern` component will be used to render it. Any other blocks will use the default rendering unless you provide a custom component in `blockDefinitions`.
+
+> [!TIP]
+> If a block is overridden both globally (`snapwp.config.ts`) and per-route (`EditorBlocksRenderer` prop), the per-route override takes precedence.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -76,6 +76,7 @@ These components provide developer-friendly APIs for rendering core WordPress bl
 | core-quote         | CoreQuote        |
 | core-separator     | CoreSeparator    |
 | core-spacer        | CoreSpacer       |
+| core-synced-pattern| CoreSyncedPattern|
 | core-template-part | CoreTemplatePart |
 | core-verse         | CoreVerse        |
 | core-video         | CoreVideo        |

--- a/packages/blocks/src/blocks/core-synced-pattern.tsx
+++ b/packages/blocks/src/blocks/core-synced-pattern.tsx
@@ -1,0 +1,42 @@
+import { cn, getClassNamesFromString } from '@snapwp/core';
+import type {
+	CoreSyncedPattern as CoreSyncedPatternType,
+	CoreSyncedPatternProps,
+} from '@snapwp/types';
+import type { ReactNode } from 'react';
+
+/**
+ * Renders the core/synced-pattern block.
+ *
+ * @param {Object}                                    props              The props for the block component.
+ * @param {CoreSyncedPatternProps['attributes']}      props.attributes   Block attributes.
+ * @param {ReactNode}                                 props.children     The block's children.
+ * @param {CoreSyncedPatternProps['renderedHtml']}    props.renderedHtml The block's rendered HTML.
+ *
+ * @return The rendered block.
+ */
+export const CoreSyncedPattern: CoreSyncedPatternType = ({
+	attributes,
+	children,
+	renderedHtml,
+}: CoreSyncedPatternProps): ReactNode => {
+	const { style } = attributes || {};
+	const styleObject = getStylesFromAttributes({ style });
+
+	/**
+	 * @todo replace with cssClassName once it's supported.
+	 */
+	const classNamesFromString = renderedHtml
+		? getClassNamesFromString(renderedHtml)
+		: '';
+	const classNames = cn(classNamesFromString);
+
+	return (
+		<div
+			className={classNames}
+			{...(styleObject && { style: styleObject })}
+		>
+			{children}
+		</div>
+	);
+}; 

--- a/packages/blocks/src/blocks/index.ts
+++ b/packages/blocks/src/blocks/index.ts
@@ -24,6 +24,7 @@ import { CorePullquote } from './core-pullquote';
 import { CoreQuote } from './core-quote';
 import { CoreSeparator } from './core-separator';
 import { CoreSpacer } from './core-spacer';
+import { CoreSyncedPattern } from './core-synced-pattern';
 import { CoreTemplatePart } from './core-template-part';
 import { CoreVerse } from './core-verse';
 import { CoreVideo } from './core-video';
@@ -58,6 +59,7 @@ export const blocks: BlockDefinitions = {
 	CoreQuote,
 	CoreSeparator,
 	CoreSpacer,
+	CoreSyncedPattern,
 	CoreTemplatePart,
 	CoreVerse,
 	CoreVideo,

--- a/packages/blocks/src/blocks/tests/core-synced-pattern.test.tsx
+++ b/packages/blocks/src/blocks/tests/core-synced-pattern.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+
+import { CoreSyncedPattern } from '../core-synced-pattern';
+
+describe('CoreSyncedPattern Component', () => {
+	it('renders children correctly', () => {
+		const { container } = render(
+			<CoreSyncedPattern>
+				<div>Test Child</div>
+			</CoreSyncedPattern>
+		);
+
+		expect(container).toHaveTextContent('Test Child');
+	});
+
+	it('applies className from renderedHtml', () => {
+		const renderedHtml = '<div class="test-class another-class"></div>';
+		const { container } = render(
+			<CoreSyncedPattern renderedHtml={renderedHtml}>
+				<div>Test Child</div>
+			</CoreSyncedPattern>
+		);
+
+		const wrapper = container.firstChild;
+		expect(wrapper).toHaveClass('test-class', 'another-class');
+	});
+
+	it('applies style from attributes', () => {
+		const style = JSON.stringify({ color: 'red', padding: '10px' });
+		const { container } = render(
+			<CoreSyncedPattern attributes={{ style }}>
+				<div>Test Child</div>
+			</CoreSyncedPattern>
+		);
+
+		const wrapper = container.firstChild;
+		expect(wrapper).toHaveStyle({
+			color: 'red',
+			padding: '10px',
+		});
+	});
+
+	it('handles empty attributes gracefully', () => {
+		const { container } = render(
+			<CoreSyncedPattern attributes={undefined}>
+				<div>Test Child</div>
+			</CoreSyncedPattern>
+		);
+
+		expect(container).toHaveTextContent('Test Child');
+	});
+
+	it('handles empty renderedHtml gracefully', () => {
+		const { container } = render(
+			<CoreSyncedPattern renderedHtml={undefined}>
+				<div>Test Child</div>
+			</CoreSyncedPattern>
+		);
+
+		expect(container).toHaveTextContent('Test Child');
+	});
+
+	it('combines className and style correctly', () => {
+		const renderedHtml = '<div class="test-class"></div>';
+		const style = JSON.stringify({ color: 'blue' });
+		const { container } = render(
+			<CoreSyncedPattern
+				renderedHtml={renderedHtml}
+				attributes={{ style }}
+			>
+				<div>Test Child</div>
+			</CoreSyncedPattern>
+		);
+
+		const wrapper = container.firstChild;
+		expect(wrapper).toHaveClass('test-class');
+		expect(wrapper).toHaveStyle({ color: 'blue' });
+	});
+}); 

--- a/packages/types/src/blocks/props/core-synced-pattern.ts
+++ b/packages/types/src/blocks/props/core-synced-pattern.ts
@@ -1,0 +1,8 @@
+import type { BaseProps } from '../base';
+import type { ComponentType, PropsWithChildren } from 'react';
+
+export type CoreSyncedPatternProps = PropsWithChildren<BaseProps<{
+	style?: string;
+}>>;
+
+export type CoreSyncedPattern = ComponentType<CoreSyncedPatternProps>; 

--- a/packages/types/src/blocks/props/index.ts
+++ b/packages/types/src/blocks/props/index.ts
@@ -27,4 +27,5 @@ export * from './core-spacer';
 export * from './core-template-part';
 export * from './core-verse';
 export * from './core-video';
+export * from './core-synced-pattern';
 export * from './default';


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR adds support for the `aria-label` attribute to the `CoreButton` component. The attribute is conditionally applied to `<button>`, `<a>`, and `<Link>` elements based on the `attributes` prop.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
This PR improves accessibility by allowing screen readers to interpret the purpose of the button or link using the provided `aria-label`. It addresses a gap where `aria-label` was not being rendered even if passed via attributes.

### Related Issue(s):
- Fixes #96

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
- Destructured `ariaLabel` from the `attributes` object.
- Included it in the `commonProps` object conditionally using `'aria-label': ariaLabel ?? undefined`.
- Ensured that `commonProps` is spread into all output elements (`button`, `Link`, and `a`).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Run the local development server.
2. Render a `CoreButton` block with the `ariaLabel` attribute provided in the block settings or data.
3. Inspect the rendered element (e.g., button or link).
4. Confirm that the `aria-label` attribute is present and correctly set.

## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->
_Not applicable_ – change is visible in HTML output and benefits screen readers.

## Additional Info
<!-- Please include any relevant logs, error output, etc -->
None.

## Checklist

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [x] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [x] I have added a changeset for this PR using `npm run changeset`.
