### PR TITLE
fix: add TSDoc `@typeParam` to `jsdoc/check-tag-names` allowlist

### DIFF
--- a/.changeset/witty-maps-chew.md
+++ b/.changeset/witty-maps-chew.md
@@ -1,0 +1,5 @@
+---
+"@snapwp/eslint-config": patch
+---
+
+fix: add TSDoc `@typeParam` to `jsdoc/check-tag-names` allowlist.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -76,6 +76,7 @@ module.exports = {
 		// Turn of JSdoc types and use TypeScript types instead.
 		'jsdoc/no-types': [ 'off' ],
 		'jsdoc/require-param-type': [ 'error' ],
+		'jsdoc/check-tag-names': [ 'error' ],
 		'jsdoc/require-returns': [ 'warn' ],
 
 		// Restrict the use of empty functions.

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -12,5 +12,12 @@ module.exports = {
 	],
 	rules: {
 		'n/no-process-env': [ 'error' ],
+		// Add support for tsdoc `@typeParam` to JSdoc.
+		'jsdoc/check-tag-names': [
+			'warn',
+			{
+				definedTags: [ 'typeParam' ],
+			},
+		],
 	},
 };


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR adds `@typeParam` to the `jsdoc/check-tag-names` allowlist, and then enforces that rule as an `error` on our internal repo.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->

Eslint warnings should still be resolved.

### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of: #123
-->


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->




## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

`npm run lint`

## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->

Before/ after:

![image](https://github.com/user-attachments/assets/e1cfbd21-9203-471a-a2c3-e347349fdb24)


## Additional Info
<!-- Please include any relevant logs, error output, etc -->


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [x] My code has detailed inline documentation.
-   [x] I have added unit tests to verify the code works as intended.
-   [x] I have updated the project documentation as needed.
-   [x] I have added a changeset for this PR using `npm run changeset`.
