### PR TITLE
Fix/private packages GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
                     private="$(npm query ".workspace#$package" | jq -r '.[0].private')"
                     if [ "$private" == "true" ]; then
                       echo "Skipping publishing private package $package"
-                      tag_exists_on_github=$(gh api -X GET "/repos/rtcamp/snapwp/releases/tags/$package@$version" &> /dev/null && echo true || echo false)
+                      tag_exists_on_github=$(gh api -X GET "/repos/${{ github.repository }}/releases/tags/$package@$version" &> /dev/null && echo true || echo false)
                       if [ "$tag_exists_on_github" == "true" ]; then
                         echo "Tag $package@$version already exists on GitHub. Skipping creating a new tag."
                       else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,9 +69,9 @@ jobs:
                       if [ "$tag_exists_on_github" == "true" ]; then
                         echo "Tag $package@$version already exists on GitHub. Skipping creating a new tag."
                       else
-                        echo "Creating tag $package@$version on GitHub"
-                        git tag "$package@$version"
-                        git push origin "$package@$version"
+                        echo "Creating release $package@$version on GitHub"
+                        bash '${{ github.workspace }}/.github/scripts/release_content.sh' "${{ github.workspace }}/$location/CHANGELOG.md" "$version"
+                        gh release create "$package@$version" --title "$package@$version" --notes-file /tmp/changelog.md
                       fi
                       continue
                     else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,10 +62,24 @@ jobs:
                     echo "Publishing $package"
                     location="$(npm query ".workspace#$package" | jq -r '.[0].location')"
                     version="$(npm query ".workspace#$package" | jq -r '.[0].version')"
-                    npm publish --access public --workspace "$location" "$package"
-                    # Make a GitHub Release
-                    bash '${{ github.workspace }}/.github/scripts/release_content.sh' "${{ github.workspace }}/$location/CHANGELOG.md" "$version"
-                    gh release create "$package@$version" --title "$package@$version" --notes-file /tmp/changelog.md
+                    private="$(npm query ".workspace#$package" | jq -r '.[0].private')"
+                    if [ "$private" == "true" ]; then
+                      echo "Skipping publishing private package $package"
+                      tag_exists_on_github=$(gh api -X GET "/repos/rtcamp/snapwp/releases/tags/$package@$version" &> /dev/null && echo true || echo false)
+                      if [ "$tag_exists_on_github" == "true" ]; then
+                        echo "Tag $package@$version already exists on GitHub. Skipping creating a new tag."
+                      else
+                        echo "Creating tag $package@$version on GitHub"
+                        git tag "$package@$version"
+                        git push origin "$package@$version"
+                      fi
+                      continue
+                    else
+                      npm publish --access public --workspace "$location" "$package"
+                      # Make a GitHub Release
+                      bash '${{ github.workspace }}/.github/scripts/release_content.sh' "${{ github.workspace }}/$location/CHANGELOG.md" "$version"
+                      gh release create "$package@$version" --title "$package@$version" --notes-file /tmp/changelog.md
+                    fi
                   done
 
                   git fetch origin main


### PR DESCRIPTION
## What
<!-- In a few words, what does this PR actually change -->
The release action fails when attempting to publish a 'private' package.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
In case of a package marked as `private` through `package.json`, the package is not published to NPM, but a github release is created. When the same package with the same version number is encountered twice, the github release creation fails.

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
Specifically for packages marked with `"private": true`, we go ahead and check if a github release exists or not. If it does, then we skip creating one, otherwise we always create one.

## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md
-->

-   [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/snapwp/blob/develop/.github/CONTRIBUTING.md).
-   [x] My code is tested to the best of my abilities.
-   [x] My code passes all lints (ESLint, tsc, prettier etc.).
-   [ ] My code has detailed inline documentation.
-   [ ] I have added unit tests to verify the code works as intended.
-   [ ] I have updated the project documentation as needed.
-   [ ] I have added a changeset for this PR using `npm run changeset`.
