### PR TITLE
Potential fix for code scanning alert no. 40: Incomplete string escaping or encoding

### DIFF
--- a/packages/core/src/utils/styles/get-class-names-from-string.ts
+++ b/packages/core/src/utils/styles/get-class-names-from-string.ts
@@ -15,7 +15,7 @@ export function getClassNamesFromString( html: string ): string[] {
 
 	const classNames = classAttribute
 		.replace( 'class="', '' )
-		.replace( '"', '' )
+		.slice( 0, -1 )
 		.split( ' ' )
 		.filter( Boolean ); // Filter out empty strings
 


### PR DESCRIPTION
Potential fix for [https://github.com/rtCamp/snapwp/security/code-scanning/40](https://github.com/rtCamp/snapwp/security/code-scanning/40)

Generally, to fix this type of issue you should avoid using `String.prototype.replace` with a plain string when you intend to remove or escape all or specific occurrences of a character. Instead, either use a global regular expression (`/.../g`) to operate on all occurrences, or use a structurally precise manipulation such as slicing off a known prefix/suffix or using a capturing regex that extracts just what you need.

For this specific function, we know `classAttribute` is a string like `class="foo bar baz"` due to the preceding regex. We can robustly extract the class names by either:
- Using another regex to capture only the content between the quotes, or
- Removing the known prefix `class="` and then removing only the final trailing `"` via `slice` rather than a generic `replace`.

The minimal change, preserving all existing behavior, is:

1. Keep the `classAttribute` match as-is.
2. Replace the chained `.replace( 'class="', '' ).replace( '"', '' )` with:
   - First remove the prefix using `replace('class="', '')` (which is safe because it should appear only at the start); and
   - Then remove only the last character (the trailing `"`), via `.slice(0, -1)`.

This avoids incomplete string replacement, does not change any public API behavior, and does not require any imports or new helpers. All changes are within `packages/core/src/utils/styles/get-class-names-from-string.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
