### PR TITLE
chore(dependabot): use 'widen' versioning strategy for npm ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
           - 'packages/*'
       schedule:
           interval: 'weekly'
+      versioning-strategy: 'widen'
       cooldown:
           semver-major-days: 30
           semver-minor-days: 7


### PR DESCRIPTION
Updates `.github/dependabot.yml` to set the `versioning-strategy` for `npm` to `'widen'`. This change optimizes Dependabot for a library monorepo where we want to preserve back-compatibility. Major version updates will now broaden the supported range (e.g. `^6 || ^7`) rather than replacing the old version, and minor/patch updates will just bump the lockfile if they fit within the existing semver range.

---
*PR created automatically by Jules for task [35550163680976490](https://jules.google.com/task/35550163680976490) started by @justlevine*